### PR TITLE
use md5 instead of murmur to follow the convention in the clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3185,8 +3185,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3207,14 +3206,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3229,20 +3226,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3359,8 +3353,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3372,7 +3365,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3387,7 +3379,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3395,14 +3386,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3421,7 +3410,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3502,8 +3490,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3515,7 +3502,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3601,8 +3587,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3638,7 +3623,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3658,7 +3642,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3702,14 +3685,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "express": "^4.17.0",
     "memoizee": "^0.4.4",
     "merge2": "^1.2.3",
-    "murmurhash-native": "^3.4.1",
     "node-fetch": "^2.6.0",
     "qs": "^6.7.0",
     "streamr-client-protocol": "^2.1.0",

--- a/src/partition.js
+++ b/src/partition.js
@@ -1,4 +1,4 @@
-const murmur = require('murmurhash-native').murmurHash
+const crypto = require('crypto')
 
 module.exports = function partition(partitionCount, partitionKey) {
     if (!partitionCount) {
@@ -7,9 +7,8 @@ module.exports = function partition(partitionCount, partitionKey) {
         // Fast common case
         return 0
     } else if (partitionKey) {
-        const bytes = Buffer.from(partitionKey, 'utf8')
-        const resultBytes = murmur(bytes, 0, 'buffer')
-        const intHash = resultBytes.readInt32LE()
+        const buffer = crypto.createHash('md5').update(partitionKey).digest()
+        const intHash = buffer.readInt32LE()
         return Math.abs(intHash) % partitionCount
     } else {
         // Fallback to random partition if no key

--- a/test/unit/Partitioner.test.js
+++ b/test/unit/Partitioner.test.js
@@ -15,16 +15,16 @@ describe('partition', () => {
     })
 
     // eslint-disable-next-line max-len
-    it('uses murmur2 partitioner and produces same results as org.apache.kafka.common.utils.Utils.murmur2(byte[])', () => {
+    it('should use md5 partitioner and produce same results as crypto.createHash(md5).update(string).digest()', () => {
         const keys = []
         for (let i = 0; i < 100; i++) {
             keys.push(`key-${i}`)
         }
-        // Results must be the same as those produced by StreamService#partition()
-        const correctResults = [5, 6, 3, 9, 3, 0, 2, 8, 2, 6, 9, 5, 5, 8, 5, 0, 0, 7, 2, 8, 5, 6,
-            8, 1, 7, 9, 2, 1, 8, 5, 6, 4, 3, 3, 1, 7, 1, 5, 2, 8, 3, 3, 8, 6, 8, 7, 4, 8, 2, 3, 5,
-            2, 8, 8, 8, 9, 8, 2, 7, 7, 0, 8, 8, 5, 9, 9, 9, 7, 2, 7, 0, 4, 4, 6, 4, 8, 5, 5, 0, 8,
-            2, 5, 1, 8, 6, 8, 8, 1, 2, 0, 7, 3, 2, 2, 5, 7, 9, 6, 4, 7]
+        // Results must be the same as those produced by md5
+        const correctResults = [6, 7, 4, 4, 9, 1, 8, 0, 6, 6, 7, 6, 7, 3, 2, 2, 0, 9, 4, 9, 9, 5, 5,
+            1, 7, 3, 0, 6, 5, 6, 3, 6, 3, 5, 6, 2, 3, 6, 7, 2, 1, 3, 2, 7, 1, 1, 5, 1, 4, 0, 1, 9, 7,
+            4, 2, 3, 2, 9, 7, 7, 4, 3, 5, 4, 5, 3, 9, 0, 4, 8, 1, 7, 4, 8, 1, 2, 9, 9, 5, 3, 5, 0, 9,
+            4, 3, 9, 6, 7, 8, 6, 4, 6, 0, 1, 1, 5, 8, 3, 9, 7]
 
         assert.equal(correctResults.length, keys.length, 'key array and result array are different size!')
 


### PR DESCRIPTION
Same fix as this commit in data-api: https://github.com/streamr-dev/data-api/commit/a69e83127bf64647b0fc4a5eb9a415ffdf37e5d9