### PR TITLE
NET-29: Add TTL to Cassandra inserts of non-storage nodes

### DIFF
--- a/src/broker.js
+++ b/src/broker.js
@@ -73,13 +73,14 @@ module.exports = async (config) => {
 
     // Start cassandra storage
     if (config.cassandra) {
-        storages.push(await startCassandraStorage(
-            config.cassandra.hosts,
-            'datacenter1',
-            config.cassandra.keyspace,
-            config.cassandra.username,
-            config.cassandra.password,
-        ))
+        storages.push(await startCassandraStorage({
+            contactPoints: config.cassandra.hosts,
+            localDataCenter: 'datacenter1',
+            keyspace: config.cassandra.keyspace,
+            username: config.cassandra.username,
+            password: config.cassandra.password,
+            useTtl: !config.network.isStorageNode
+        }))
     } else {
         console.info('Skipping Cassandra storage...')
     }

--- a/test/integration/Storage.test.js
+++ b/test/integration/Storage.test.js
@@ -51,7 +51,7 @@ function buildMsg(
     )
 }
 
-describe('Storage', () => {
+describe.each([false, true])('Storage (isBatching=%s)', (isBatching) => {
     let storage
     let streamId
     let cassandraClient
@@ -70,7 +70,12 @@ describe('Storage', () => {
     })
 
     beforeEach(async () => {
-        storage = await startCassandraStorage(contactPoints, localDataCenter, keyspace)
+        storage = await startCassandraStorage({
+            contactPoints,
+            localDataCenter,
+            keyspace,
+            isBatching
+        })
         streamId = `stream-id-${Date.now()}-${streamIdx}`
         streamIdx += 1
     })


### PR DESCRIPTION
- Add option to `Storage` constructor to enable or disable TTL for Cassandra inserts.
- Let broker configure the above option based on whether the node has been configured to be a storage or a non-storage node.
- Make `startCassandraStorage` take an object as argument for readability of code.
- Add option to `Storage` constructor to enable or disable batching for Cassandra inserts.
- Add test coverage for  non-batching Storage