### PR TITLE
Integration test for when non-mqtt connection is established to MQTT adapter

### DIFF
--- a/test/integration/non-mqtt-connection-to-mqtt-adapter.test.js
+++ b/test/integration/non-mqtt-connection-to-mqtt-adapter.test.js
@@ -1,7 +1,6 @@
 const net = require('net')
 
 const { startTracker } = require('@streamr/streamr-p2p-network')
-const { wait, waitForCondition } = require('streamr-test-utils')
 
 const createBroker = require('../../src/broker')
 


### PR DESCRIPTION
Integration test for when a non-mqtt connection is established to MQTT adapter. The following two things should happen:
1) connection is dropped
2) server does not crash 