### PR TITLE
fix: Service file launch command

### DIFF
--- a/.codedeploy-stg/after_install.sh
+++ b/.codedeploy-stg/after_install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 cd /srv/broker
 mkdir /srv/broker/.npm-global
+mv /srv/broker/.codedeploy/broker /srv/broker/.npm-global/bin/
 NPM_CONFIG_PREFIX=/srv/broker/.npm-global npm install --unsafe-perm

--- a/.codedeploy-stg/broker
+++ b/.codedeploy-stg/broker
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+node /srv/broker/app.js $1


### PR DESCRIPTION
* Need a broker file located in npm global for the service to launch the network node

The service runs with the following command 
`/srv/broker/.npm-global/bin/broker /srv/broker/config.json`
 but installing with npm install doesnt generate this file so the work around is to generate a file that will be put at that location and to be executed.