### PR TITLE
HTTP adapter: inform client of error in content

### DIFF
--- a/src/errors/InvalidMessageContentError.js
+++ b/src/errors/InvalidMessageContentError.js
@@ -1,3 +1,0 @@
-module.exports = class InvalidMessageContentError extends Error {
-
-}

--- a/src/http/DataProduceEndpoints.js
+++ b/src/http/DataProduceEndpoints.js
@@ -1,8 +1,8 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { InvalidJsonError } = require('streamr-client-protocol').Errors
 
-const InvalidMessageContentError = require('../errors/InvalidMessageContentError')
 const partition = require('../partition')
 
 const authenticationMiddleware = require('./RequestAuthenticatorMiddleware')
@@ -108,7 +108,7 @@ module.exports = (streamFetcher, publisher, partitionFn = partition) => {
                 res.status(200)
                     .send(/* empty success response */)
             } catch (err) {
-                if (err instanceof InvalidMessageContentError) {
+                if (err instanceof InvalidJsonError) {
                     res.status(400).send({
                         error: err.message,
                     })

--- a/test/integration/broker-resistance-to-invalid-data.test.js
+++ b/test/integration/broker-resistance-to-invalid-data.test.js
@@ -1,0 +1,102 @@
+const http = require('http')
+
+const { startTracker } = require('streamr-network')
+const StreamrClient = require('streamr-client')
+
+const createBroker = require('../../src/broker')
+
+const trackerPort = 12420
+const brokerPort = 12421
+const httpPort = 12422
+
+function createClient(wsPort, apiKey) {
+    return new StreamrClient({
+        url: `ws://localhost:${wsPort}/api/v1/ws`,
+        restUrl: 'http://localhost:8081/streamr-core/api/v1',
+        auth: {
+            apiKey
+        }
+    })
+}
+
+describe('broker resistance to invalid data', () => {
+    let tracker
+    let broker
+    let streamId
+
+    beforeEach(async () => {
+        tracker = await startTracker('127.0.0.1', trackerPort, 'tracker')
+        broker = await createBroker({
+            network: {
+                id: 'broker',
+                hostname: '127.0.0.1',
+                port: brokerPort,
+                advertisedWsUrl: null,
+                tracker: `ws://127.0.0.1:${trackerPort}`,
+                isStorageNode: false
+            },
+            cassandra: false,
+            reporting: false,
+            streamrUrl: 'http://localhost:8081/streamr-core',
+            adapters: [
+                {
+                    name: 'http',
+                    port: httpPort
+                }
+            ],
+        })
+
+        // Create new stream
+        const client = createClient(0, 'tester1-api-key')
+        const freshStream = await client.createStream({
+            name: 'broker-resistance-to-invalid-data.test.js-' + Date.now()
+        })
+        streamId = freshStream.id
+        await client.ensureDisconnected()
+    })
+
+    afterEach(async () => {
+        await broker.close()
+        await tracker.stop()
+    })
+
+    test('pushing invalid data to HTTP adapter returns 400 error & does not crash broker', (done) => {
+        const invalidData = '###!!THIS-DATA-IS-NOT-JSON!!###'
+
+        const request = http.request({
+            hostname: '127.0.0.1',
+            port: httpPort,
+            path: `/api/v1/streams/${streamId}/data`,
+            method: 'POST',
+            headers: {
+                Authorization: 'token tester1-api-key',
+                'Content-Type': 'application/json',
+                'Content-Length': invalidData.length
+            }
+        }, (res) => {
+            let data = ''
+
+            res.on('data', (chunk) => {
+                data += chunk
+            })
+
+            res.on('end', () => {
+                expect(res.statusCode).toEqual(400)
+                const asObject = JSON.parse(data)
+                expect(Object.keys(asObject)).toEqual(['error'])
+                done()
+            })
+        })
+
+        request.on('error', (err) => {
+            if (err) {
+                done(err)
+            } else {
+                done(new Error('error cb'))
+            }
+        })
+
+        request.write(invalidData)
+        request.end()
+    })
+})


### PR DESCRIPTION
- Properly handle parsing error of content in publish endpoint of HTTP adapter by letting client know they have error with 400 status code and message instead of console.error logging problem.
- Add test to verify above behavior + broker does not crash