### PR TITLE
Configuration files for 3 brokers running on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ EXPOSE 8891
 # MQTT
 EXPOSE 9000
 
-ENV CONFIG_FILE configs/docker.env.json
+ENV CONFIG_FILE configs/docker-1.env.json
 ENV STREAMR_URL http://127.0.0.1:8081/streamr-core
-ENV NETWORK_ID development-node-1
 
-CMD node app.js ${CONFIG_FILE} --streamrUrl=${STREAMR_URL} --networkId=${NETWORK_ID}
+CMD node app.js ${CONFIG_FILE} --streamrUrl=${STREAMR_URL}

--- a/configs/docker-1.env.json
+++ b/configs/docker-1.env.json
@@ -1,6 +1,6 @@
 {
   "network": {
-    "id": "development-node-1",
+    "id": "docker-1",
     "hostname": "127.0.0.1",
     "port": "30315",
     "advertisedWsUrl": null,

--- a/configs/docker-2.env.json
+++ b/configs/docker-2.env.json
@@ -2,7 +2,7 @@
   "network": {
     "id": "docker-2",
     "hostname": "127.0.0.1",
-    "port": "30315",
+    "port": "30316",
     "advertisedWsUrl": null,
     "tracker": "ws://tracker:30300",
     "isStorageNode": false
@@ -16,15 +16,15 @@
   "adapters": [
     {
       "name": "ws",
-      "port": 8890
+      "port": 8790
     },
     {
       "name": "http",
-      "port": 8891
+      "port": 8791
     },
     {
       "name": "mqtt",
-      "port": 9000,
+      "port": 9100,
       "streamsTimeout": 300000
     }
   ]

--- a/configs/docker-2.env.json
+++ b/configs/docker-2.env.json
@@ -1,0 +1,31 @@
+{
+  "network": {
+    "id": "docker-2",
+    "hostname": "127.0.0.1",
+    "port": "30315",
+    "advertisedWsUrl": null,
+    "tracker": "ws://tracker:30300",
+    "isStorageNode": false
+  },
+  "cassandra": false,
+  "reporting": {
+    "reportingIntervalSeconds": 10
+  },
+  "sentry": false,
+  "streamrUrl": "http://localhost:8081/streamr-core",
+  "adapters": [
+    {
+      "name": "ws",
+      "port": 8890
+    },
+    {
+      "name": "http",
+      "port": 8891
+    },
+    {
+      "name": "mqtt",
+      "port": 9000,
+      "streamsTimeout": 300000
+    }
+  ]
+}

--- a/configs/docker-3.env.json
+++ b/configs/docker-3.env.json
@@ -1,0 +1,31 @@
+{
+  "network": {
+    "id": "docker-3",
+    "hostname": "127.0.0.1",
+    "port": "30315",
+    "advertisedWsUrl": null,
+    "tracker": "ws://tracker:30300",
+    "isStorageNode": false
+  },
+  "cassandra": false,
+  "reporting": {
+    "reportingIntervalSeconds": 10
+  },
+  "sentry": false,
+  "streamrUrl": "http://localhost:8081/streamr-core",
+  "adapters": [
+    {
+      "name": "ws",
+      "port": 8890
+    },
+    {
+      "name": "http",
+      "port": 8891
+    },
+    {
+      "name": "mqtt",
+      "port": 9000,
+      "streamsTimeout": 300000
+    }
+  ]
+}

--- a/configs/docker-3.env.json
+++ b/configs/docker-3.env.json
@@ -2,7 +2,7 @@
   "network": {
     "id": "docker-3",
     "hostname": "127.0.0.1",
-    "port": "30315",
+    "port": "30317",
     "advertisedWsUrl": null,
     "tracker": "ws://tracker:30300",
     "isStorageNode": false
@@ -16,15 +16,15 @@
   "adapters": [
     {
       "name": "ws",
-      "port": 8890
+      "port": 8690
     },
     {
       "name": "http",
-      "port": 8891
+      "port": 8691
     },
     {
       "name": "mqtt",
-      "port": 9000,
+      "port": 9200,
       "streamsTimeout": 300000
     }
   ]


### PR DESCRIPTION
Configuration files for 3 brokers running on Docker.
- First broker `docker-1` is storage node.
- Second and third brokers are non-storage nodes `docker-2` and `docker-3`. 

Probably some further tweaking of configs is necessary because of duplicate port usage and firewalls?