### PR TITLE
Fix Docker firewall issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ EXPOSE 8891
 # MQTT
 EXPOSE 9000
 
+ENV DEBUG=streamr:logic:*
 ENV CONFIG_FILE configs/docker-1.env.json
 ENV STREAMR_URL http://127.0.0.1:8081/streamr-core
 

--- a/configs/docker-1.env.json
+++ b/configs/docker-1.env.json
@@ -1,9 +1,9 @@
 {
   "network": {
     "id": "docker-1",
-    "hostname": "127.0.0.1",
+    "hostname": null,
     "port": "30315",
-    "advertisedWsUrl": null,
+    "advertisedWsUrl": "ws://10.200.10.1:30315",
     "tracker": "ws://tracker:30300",
     "isStorageNode": true
   },

--- a/configs/docker-2.env.json
+++ b/configs/docker-2.env.json
@@ -1,9 +1,9 @@
 {
   "network": {
     "id": "docker-2",
-    "hostname": "127.0.0.1",
+    "hostname": null,
     "port": "30316",
-    "advertisedWsUrl": null,
+    "advertisedWsUrl": "ws://10.200.10.1:30316",
     "tracker": "ws://tracker:30300",
     "isStorageNode": false
   },

--- a/configs/docker-3.env.json
+++ b/configs/docker-3.env.json
@@ -1,9 +1,9 @@
 {
   "network": {
     "id": "docker-3",
-    "hostname": "127.0.0.1",
+    "hostname": null,
     "port": "30317",
-    "advertisedWsUrl": null,
+    "advertisedWsUrl": "ws://10.200.10.1:30317",
     "tracker": "ws://tracker:30300",
     "isStorageNode": false
   },


### PR DESCRIPTION
Fix issue in Docker in which broker nodes were unable to connect to each other based on tracker instructions.

- Add ability to specify `ENV` variable for more logging of broker-node. By default use level `streamr:logic:*`.
- Set `hostname = null` so that `uWS` library properly binds to an outwards-facing network interface (as opposed to loopback?)
- Use `advertisedWsUrl` with IP address `10.200.10.1` so that brokers advertise a "public" IP address as opposed to a private one that is only accessible within the same docker image. 