### PR TITLE
decrease logging frequency in docker environments

### DIFF
--- a/configs/docker-1.env.json
+++ b/configs/docker-1.env.json
@@ -16,7 +16,7 @@
     "keyspace": "streamr_dev"
   },
   "reporting": {
-    "reportingIntervalSeconds": 10
+    "reportingIntervalSeconds": 120
   },
   "sentry": false,
   "streamrUrl": "http://localhost:8081/streamr-core",

--- a/configs/docker-2.env.json
+++ b/configs/docker-2.env.json
@@ -9,7 +9,7 @@
   },
   "cassandra": false,
   "reporting": {
-    "reportingIntervalSeconds": 10
+    "reportingIntervalSeconds": 120
   },
   "sentry": false,
   "streamrUrl": "http://localhost:8081/streamr-core",

--- a/configs/docker-3.env.json
+++ b/configs/docker-3.env.json
@@ -9,7 +9,7 @@
   },
   "cassandra": false,
   "reporting": {
-    "reportingIntervalSeconds": 10
+    "reportingIntervalSeconds": 120
   },
   "sentry": false,
   "streamrUrl": "http://localhost:8081/streamr-core",


### PR DESCRIPTION
Decrease logging frequency in docker environment so that the global streamr-docker-dev logs are slightly more readable. 