### PR TITLE
fix: Use git tag value.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,10 +78,10 @@ jobs:
     script:
     - mkdir $TRAVIS_BUILD_DIR/build
     - mkdir $TRAVIS_BUILD_DIR/upload
-    - sed -i "s/TAG/$TAG/g" .codedeploy/after_install.sh
+    - sed -i "s/TAG/$TRAVIS_TAG/g" .codedeploy/after_install.sh
     - mv .codedeploy/appspec.yml build/appspec.yml
     - mv .codedeploy/ build/
-    - cd build; tar -czvf $TRAVIS_BUILD_DIR/upload/broker-${TAG}.tar .;
+    - cd build; tar -czvf $TRAVIS_BUILD_DIR/upload/broker-${TRAVIS_TAG}.tar .;
       tar -czvf $TRAVIS_BUILD_DIR/upload/latest.tar .;
     - cd $TRAVIS_BUILD_DIR;
     deploy:


### PR DESCRIPTION
TRAVIS_TAG: If the current build is for a git tag, this variable is set to the tag’s name.