### PR TITLE
improve logging of MicroBatchingStrategy

### DIFF
--- a/src/MicroBatchingStrategy.js
+++ b/src/MicroBatchingStrategy.js
@@ -25,8 +25,9 @@ class SharedContext {
             await this.insertFn(streamMessages)
             this._resetFailMultiplier()
         } catch (e) {
+            const key = `${streamMessages[0].getStreamId()}::${streamMessages[0].getStreamPartition()}`
             if (this.logErrors) {
-                console.error(e)
+                console.error(`Failed to insert (${key}): ${e.stack ? e.stack : e}`)
             }
             this._growFailMultiplier()
             throw e


### PR DESCRIPTION
When MicroBatchingStrategy fails to insert a batch to Cassandra, log not
only the error but also the stream id and partition of the associated
batch.