### PR TITLE
add 1h timeout to WebsocketServer

### DIFF
--- a/src/websocket/WebsocketServer.js
+++ b/src/websocket/WebsocketServer.js
@@ -96,7 +96,7 @@ module.exports = class WebsocketServer extends EventEmitter {
             /* Options */
             compression: 0,
             maxPayloadLength: 1024 * 1024,
-            idleTimeout: 0,
+            idleTimeout: 3600, // 1 hour
             open: (ws, req) => {
                 const connection = new Connection(ws, req)
                 this.connections.set(connection.id, connection)


### PR DESCRIPTION
It seems like WebSocket connections are currently leaking when they are not properly closed with handshake. Let's at least close them after an hour. With ping/pong messages we could reduce this much much lower. I created a JIRA ticket for that. 