### PR TITLE
Dockerfile: Rework Node installation procedure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,12 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /
 ENV PATH="/node-$NODE_VERSION-linux-x64/bin:${PATH}"
-COPY --from=builder /node-$NODE_VERSION-linux-x64/ /node-$NODE_VERSION-linux-x64/
+COPY --from=builder --chown=root:root /node-$NODE_VERSION-linux-x64/ /node-$NODE_VERSION-linux-x64/
 
 RUN useradd -ms /bin/bash node
 USER node
 WORKDIR /home/node
-COPY --from=builder /home/node/ ./
+COPY --from=builder --chown=node:node /home/node/ ./
 
 # Make ports available to the world outside this container
 EXPOSE 30315

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,42 @@
 FROM ubuntu:16.04 AS builder
+ARG NODE_VERSION="v10.18.0"
 WORKDIR /app
 COPY . /app
-RUN apt-get update && apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 RUN apt-get update && apt-get install -y \
 	build-essential \
+	curl \
 	git \
-	nodejs \
+	python3 \
 	&& rm -rf /var/lib/apt/lists/*
+WORKDIR /
+RUN curl -s -O "https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz"
+RUN tar xzf "node-${NODE_VERSION}-linux-x64.tar.gz"
+ENV PATH="/node-${NODE_VERSION}-linux-x64/bin:${PATH}"
 RUN node --version
+RUN npm --version
+RUN useradd -ms /bin/bash node
+USER node
+WORKDIR /home/node
+COPY ./ ./
 RUN npm ci
 
 FROM ubuntu:16.04
+ARG NODE_VERSION="v10.18.0"
 WORKDIR /app
 COPY --from=builder /app/ .
-RUN apt-get update && apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 RUN apt-get update && apt-get install -y \
-	nodejs \
+	curl \
 	&& rm -rf /var/lib/apt/lists/*
 
-USER nobody
+WORKDIR /
+ENV PATH="/node-$NODE_VERSION-linux-x64/bin:${PATH}"
+COPY --from=builder /node-$NODE_VERSION-linux-x64/ /node-$NODE_VERSION-linux-x64/
+
+RUN useradd -ms /bin/bash node
+USER node
+WORKDIR /home/node
+COPY --from=builder /home/node/ ./
+
 # Make ports available to the world outside this container
 EXPOSE 30315
 # WebSocket


### PR DESCRIPTION
Version installed from https://deb.nodesource.com/setup_10.x can vary.

- Install exact version of Node
- Install python3 on builder, since some node library requires
- Replace nobody with node