### PR TITLE
hotfix: cassandra errors crashing broker

### DIFF
--- a/src/Storage.js
+++ b/src/Storage.js
@@ -105,7 +105,8 @@ class Storage extends EventEmitter {
                 readableStream.push(null)
             })
             .catch((err) => {
-                readableStream.emit('error', err)
+                console.error(err)
+                readableStream.push(null)
             })
 
         return readableStream
@@ -267,6 +268,10 @@ class Storage extends EventEmitter {
                 cassandraStream.pause()
                 setImmediate(() => cassandraStream.resume())
             }
+        })
+
+        cassandraStream.on('error', (err) => {
+            console.error(err)
         })
 
         return cassandraStream.pipe(new Transform({


### PR DESCRIPTION
New `cassandra-driver` version seems to be stricter about catching and handling errors. Thus I added simple `console.error` handling. Also made sure to properly close `requestLast` request on error situation.