### PR TITLE
Handle 403 in FieldDetector

### DIFF
--- a/src/websocket/FieldDetector.js
+++ b/src/websocket/FieldDetector.js
@@ -1,3 +1,5 @@
+const HttpError = require('../errors/HttpError')
+
 module.exports = class FieldDetector {
     constructor(streamFetcher) {
         this.streamFetcher = streamFetcher
@@ -28,7 +30,10 @@ module.exports = class FieldDetector {
             try {
                 await this.streamFetcher.setFields(stream.id, fields, apiKey, sessionToken)
             } catch (e) {
-                this.configuredStreamIds.delete(stream.id)
+                // Can try again unless we get a 403 response (permission denied)
+                if (!(e instanceof HttpError && e.code === 403)) {
+                    this.configuredStreamIds.delete(stream.id)
+                }
                 throw e
             }
         }


### PR DESCRIPTION
Previously the `FieldDetector` was written in a way that it assumed that the user has `read` and `write` permissions to the stream.

In the new permissions system, it's now possible that a user has `stream_get` and `stream_publish`, but NOT `stream_edit`, which is required to set the fields config. When detecting fields, this leads to a situation where the user attempts to set the fields on every message. They get a `403`, and on the next publish they retry, etc. etc. - leading to a lot of failed attempts to set the fields.

This small PR fixes the situation so that if a `403` response is received, we won't retry setting fields for that stream.