### PR TITLE
hotfix: resends closing too early

### DIFF
--- a/src/websocket/Connection.js
+++ b/src/websocket/Connection.js
@@ -10,10 +10,7 @@ function generateId() {
     return id
 }
 
-const LOW_BACK_PRESSURE = 1024 * 1024 * 2 // 2 megabytes
-const HIGH_BACK_PRESSURE = 1024 * 1024 * 16 // 16 megabytes
-
-module.exports = class Connection extends EventEmitter {
+class Connection extends EventEmitter {
     constructor(socket, controlLayerVersion, messageLayerVersion) {
         super()
         this.id = generateId()
@@ -70,10 +67,12 @@ module.exports = class Connection extends EventEmitter {
     }
 
     evaluateBackPressure() {
-        if (!this.highBackPressure && this.socket.getBufferedAmount() > HIGH_BACK_PRESSURE) {
+        if (!this.highBackPressure && this.socket.getBufferedAmount() > Connection.HIGH_BACK_PRESSURE) {
+            logger.debug('Back pressure HIGH for %s at %d', this.id, this.socket.getBufferedAmount())
             this.emit('highBackPressure')
             this.highBackPressure = true
-        } else if (this.highBackPressure && this.socket.getBufferedAmount() < LOW_BACK_PRESSURE) {
+        } else if (this.highBackPressure && this.socket.getBufferedAmount() < Connection.LOW_BACK_PRESSURE) {
+            logger.debug('Back pressure LOW for %s at %d', this.id, this.socket.getBufferedAmount())
             this.emit('lowBackPressure')
             this.highBackPressure = false
         }
@@ -94,3 +93,8 @@ module.exports = class Connection extends EventEmitter {
         }
     }
 }
+
+Connection.LOW_BACK_PRESSURE = 1024 * 1024 // 1 megabytes
+Connection.HIGH_BACK_PRESSURE = 1024 * 1024 * 2 // 2 megabytes
+
+module.exports = Connection

--- a/test/integration/message-ordering-in-ws-adapter.test.js
+++ b/test/integration/message-ordering-in-ws-adapter.test.js
@@ -1,4 +1,4 @@
-const { startTracker, startNetworkNode, Protocol } = require('streamr-network')
+const { startTracker, startNetworkNode, startStorageNode, Protocol } = require('streamr-network')
 const intoStream = require('into-stream')
 const { wait, waitForCondition } = require('streamr-test-utils')
 
@@ -118,7 +118,7 @@ describe('message ordering and gap filling in websocket adapter', () => {
     it('missing messages are gap filled by ws adapter', async () => {
         // Set up new network node that has missing messages in its storage
         const resendRequests = []
-        nodeWithMissingMessages = await startNetworkNode({
+        nodeWithMissingMessages = await startStorageNode({
             host: '127.0.0.1',
             port: networkPort3,
             id: 'missingMessagesNode',


### PR DESCRIPTION
Fixed resend messages not getting delivered. Reason was that we didn't have `maxBackPressure` option set on uWS.