### PR TITLE
Test refactor

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Cache streamr-docker-dev environment
         uses: actions/cache@v2
         with:
-        path: ${GITHUB_WORKSPACE}/streamr-docker-dev
-        key: streamr-docker-dev
+          path: ${GITHUB_WORKSPACE}/streamr-docker-dev
+          key: streamr-docker-dev
       - name: streamr-docker-dev
         run: |
           if streamr-docker-dev; then git pull; else git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git; fi

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,16 +28,10 @@ jobs:
       - run: npm run eslint
       - run: npm run build --if-present
       - run: npm run test-unit
-      - name: Cache streamr-docker-dev environment
-        uses: actions/cache@v2
-        with:
-          path: ${GITHUB_WORKSPACE}/streamr-docker-dev
-          key: streamr-docker-dev
       - name: streamr-docker-dev
         run: |
-          if streamr-docker-dev; then git pull; else git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git; fi
+          git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git
           sudo ifconfig docker0 10.200.10.1/24
-          streamr-docker-dev pull engine-and-editor cassandra
           ${GITHUB_WORKSPACE}/streamr-docker-dev/streamr-docker-dev/bin.sh start engine-and-editor cassandra --except tracker-1 --except tracker-2 --except tracker-3 --except broker-node-storage-1 --except broker-node-no-storage-1 --except broker-node-no-storage-2 --wait
       - run: npm run test-integration
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,10 +28,16 @@ jobs:
       - run: npm run eslint
       - run: npm run build --if-present
       - run: npm run test-unit
+      - name: Cache streamr-docker-dev environment
+        uses: actions/cache@v2
+        with:
+        path: ${GITHUB_WORKSPACE}/streamr-docker-dev
+        key: streamr-docker-dev
       - name: streamr-docker-dev
         run: |
-          git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git
+          if streamr-docker-dev; then git pull; else git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git; fi
           sudo ifconfig docker0 10.200.10.1/24
+          streamr-docker-dev pull engine-and-editor cassandra
           ${GITHUB_WORKSPACE}/streamr-docker-dev/streamr-docker-dev/bin.sh start engine-and-editor cassandra --except tracker-1 --except tracker-2 --except tracker-3 --except broker-node-storage-1 --except broker-node-no-storage-1 --except broker-node-no-storage-2 --wait
       - run: npm run test-integration
         env:

--- a/test/integration/SubscriptionManager.test.js
+++ b/test/integration/SubscriptionManager.test.js
@@ -35,8 +35,24 @@ describe('SubscriptionManager', () => {
             id: 'tracker'
         })
 
-        broker1 = await startBroker('broker1', networkPort1, trackerPort, httpPort1, wsPort1, mqttPort1, true)
-        broker2 = await startBroker('broker2', networkPort2, trackerPort, httpPort2, wsPort2, mqttPort2, true)
+        broker1 = await startBroker({
+            name: 'broker1',
+            privateKey: '0xd622f9e4dbcd8b98f12604f0af8ac1cbc75004829e505fdd0ed04f456ef52828',
+            networkPort: networkPort1,
+            trackerPort,
+            httpPort: httpPort1,
+            wsPort: wsPort1,
+            mqttPort: mqttPort1
+        })
+        broker2 = await startBroker({
+            name: 'broker2',
+            privateKey: '0xbaa8e6137a9474ecb6694ad3e4f1743732e38c36e9bdda628e651d36ed732241',
+            networkPort: networkPort2,
+            trackerPort,
+            httpPort: httpPort2,
+            wsPort: wsPort2,
+            mqttPort: mqttPort2
+        })
 
         await wait(2000)
 

--- a/test/integration/broker-drops-future-messages.test.js
+++ b/test/integration/broker-drops-future-messages.test.js
@@ -46,7 +46,15 @@ describe('broker drops future messages', () => {
             port: trackerPort,
             id: 'tracker'
         })
-        broker = await startBroker('broker', networkPort, trackerPort, httpPort, wsPort, mqttPort, false)
+        broker = await startBroker({
+            name: 'broker',
+            privateKey: '0x0381aa979c2b85ce409f70f6c64c66f70677596c7acad0b58763b0990cd5fbff',
+            networkPort,
+            trackerPort,
+            httpPort,
+            wsPort,
+            mqttPort
+        })
 
         client = createClient(wsPort)
         const freshStream = await client.createStream({

--- a/test/integration/broker-resistance-to-invalid-data.test.js
+++ b/test/integration/broker-resistance-to-invalid-data.test.js
@@ -19,7 +19,13 @@ describe('broker resistance to invalid data', () => {
             port: trackerPort,
             id: 'tracker'
         })
-        broker = await startBroker('broker', networkPort, trackerPort, httpPort, null, null, false)
+        broker = await startBroker({
+            name: 'broker',
+            privateKey: '0xbc19ba842352248cb9132cc212f35d2f947dd66a0fda1e19021f9231e069c12d',
+            networkPort,
+            trackerPort,
+            httpPort
+        })
 
         // Create new stream
         const client = createClient(0)

--- a/test/integration/broker.test.js
+++ b/test/integration/broker.test.js
@@ -15,6 +15,9 @@ const networkPort1 = 12361
 const networkPort2 = 12362
 const networkPort3 = 12363
 const trackerPort = 12370
+const broker1Key = '0x241b3f241b110ff7b3e6d52e74fea922006a83e33ff938e6e3cba8a460c02513'
+const broker2Key = '0x3816c1d1a81588cecf9ac271a4758ed08f208902c2dcda82ba1a2f458ac23a15'
+const broker3Key = '0xe8af31f5c61b64f44adcdab8c5c78a7bc0beea9dbf43af63f80544a1b84ec149'
 
 describe('websocket server', () => {
     let ws
@@ -28,7 +31,14 @@ describe('websocket server', () => {
     })
 
     it('receives unencrypted connections', async (done) => {
-        broker = await startBroker('broker1', networkPort1, trackerPort, httpPort1, wsPort1, null, false)
+        broker = await startBroker({
+            name: 'broker1',
+            privateKey: broker1Key,
+            networkPort: networkPort1,
+            trackerPort,
+            httpPort: httpPort1,
+            wsPort: wsPort1
+        })
         ws = new WebSocket(getWsUrl(wsPort1))
         ws.on('open', async () => {
             done()
@@ -37,7 +47,16 @@ describe('websocket server', () => {
     })
 
     it('receives encrypted connections', async (done) => {
-        broker = await startBroker('broker1', networkPort1, trackerPort, httpPort1, wsPort1, null, false, 'test/fixtures/key.pem', 'test/fixtures/cert.pem')
+        broker = await startBroker({
+            name: 'broker1',
+            privateKey: broker1Key,
+            networkPort: networkPort1,
+            trackerPort,
+            httpPort: httpPort1,
+            wsPort: wsPort1,
+            privateKeyFileName: 'test/fixtures/key.pem',
+            certFileName: 'test/fixtures/cert.pem'
+        })
         ws = new WebSocket(getWsUrl(wsPort1, true), {
             rejectUnauthorized: false // needed to accept self-signed certificate
         })
@@ -49,7 +68,14 @@ describe('websocket server', () => {
 
     describe('rejections', () => {
         const testRejection = async (connectionUrl) => {
-            broker = await startBroker('broker1', networkPort1, trackerPort, httpPort1, wsPort1, null, false)
+            broker = await startBroker({
+                name: 'broker1',
+                privateKey: broker1Key,
+                networkPort: networkPort1,
+                trackerPort,
+                httpPort: httpPort1,
+                wsPort: wsPort1
+            })
             ws = new WebSocket(connectionUrl)
             let gotError = false
             let closed = false
@@ -101,9 +127,33 @@ describe('broker: end-to-end', () => {
             port: trackerPort,
             id: 'tracker'
         })
-        broker1 = await startBroker('broker1', networkPort1, trackerPort, httpPort1, wsPort1, null, true)
-        broker2 = await startBroker('broker2', networkPort2, trackerPort, httpPort2, wsPort2, null, true)
-        broker3 = await startBroker('broker3', networkPort3, trackerPort, httpPort3, wsPort3, null, true)
+        broker1 = await startBroker({
+            name: 'broker1',
+            privateKey: broker1Key,
+            networkPort: networkPort1,
+            trackerPort,
+            httpPort: httpPort1,
+            wsPort: wsPort1,
+            enableCassandra: true
+        })
+        broker2 = await startBroker({
+            name: 'broker2',
+            privateKey: broker2Key,
+            networkPort: networkPort2,
+            trackerPort,
+            httpPort: httpPort2,
+            wsPort: wsPort2,
+            enableCassandra: true
+        })
+        broker3 = await startBroker({
+            name: 'broker3',
+            privateKey: broker3Key,
+            networkPort: networkPort3,
+            trackerPort,
+            httpPort: httpPort3,
+            wsPort: wsPort3,
+            enableCassandra: true
+        })
 
         client1 = createClient(wsPort1)
         client2 = createClient(wsPort2)

--- a/test/integration/local-propagation.test.js
+++ b/test/integration/local-propagation.test.js
@@ -4,10 +4,10 @@ const { wait, waitForCondition } = require('streamr-test-utils')
 const { startBroker, createClient, createMqttClient } = require('../utils')
 
 const trackerPort = 17711
-const httpPort1 = 17712
-const wsPort1 = 17713
-const networkPort1 = 17701
-const mqttPort1 = 17751
+const httpPort = 17712
+const wsPort = 17713
+const networkPort = 17701
+const mqttPort = 17751
 
 describe('local propagation', () => {
     let tracker
@@ -29,13 +29,21 @@ describe('local propagation', () => {
             id: 'tracker'
         })
 
-        broker = await startBroker('broker1', networkPort1, trackerPort, httpPort1, wsPort1, mqttPort1, true)
+        broker = await startBroker({
+            name: 'broker1',
+            privateKey: '0xfe77283a570fda0e581897b18d65632c438f0d00f9440183119c1b7e4d5275e1',
+            networkPort,
+            trackerPort,
+            httpPort,
+            wsPort,
+            mqttPort
+        })
 
-        client1 = createClient(wsPort1)
-        client2 = createClient(wsPort1)
+        client1 = createClient(wsPort)
+        client2 = createClient(wsPort)
 
-        mqttClient1 = createMqttClient(mqttPort1)
-        mqttClient2 = createMqttClient(mqttPort1)
+        mqttClient1 = createMqttClient(mqttPort)
+        mqttClient2 = createMqttClient(mqttPort)
 
         freshStream = await client1.createStream({
             name: 'local-propagation.test.js-' + Date.now()

--- a/test/integration/message-ordering-in-ws-adapter.test.js
+++ b/test/integration/message-ordering-in-ws-adapter.test.js
@@ -44,7 +44,13 @@ describe('message ordering and gap filling in websocket adapter', () => {
             trackers: [tracker.getAddress()]
         })
         publisherNode.start()
-        broker = await startBroker('broker1', networkPort2, trackerPort, null, wsPort, null, true)
+        broker = await startBroker({
+            name: 'broker1',
+            privateKey: '0x14a779a0147670070a71e539ae830c162abd8b3b74f807880b05d2cd80a9c729',
+            networkPort: networkPort2,
+            trackerPort,
+            wsPort
+        })
 
         subscriber = createClient(wsPort, {
             auth: {

--- a/test/integration/mqtt.test.js
+++ b/test/integration/mqtt.test.js
@@ -16,6 +16,9 @@ const trackerPort = 12410
 const mqttPort1 = 12551
 const mqttPort2 = 12552
 const mqttPort3 = 12553
+const broker1Key = '0x0d4f33e0e76e9f7c26178db90319617a798819acd51004693f65bd9b86444e4b'
+const broker2Key = '0xd2672dce1578d6b75a58e11fa96c978b3b500750be287fc4e7f1e894eb179da7'
+const broker3Key = '0xa417da20e3afeb69544585c6b44b95ad4d987f38cf257f4a53eab415cc12334f'
 
 describe('mqtt: end-to-end', () => {
     let tracker
@@ -40,10 +43,33 @@ describe('mqtt: end-to-end', () => {
             port: trackerPort,
             id: 'tracker'
         })
-
-        broker1 = await startBroker('broker1', networkPort1, trackerPort, httpPort1, wsPort1, mqttPort1, true)
-        broker2 = await startBroker('broker2', networkPort2, trackerPort, httpPort2, wsPort2, mqttPort2, true)
-        broker3 = await startBroker('broker3', networkPort3, trackerPort, httpPort3, wsPort3, mqttPort3, true)
+        broker1 = await startBroker({
+            name: 'broker1',
+            privateKey: broker1Key,
+            networkPort: networkPort1,
+            trackerPort,
+            httpPort: httpPort1,
+            wsPort: wsPort1,
+            mqttPort: mqttPort1
+        })
+        broker2 = await startBroker({
+            name: 'broker2',
+            privateKey: broker2Key,
+            networkPort: networkPort2,
+            trackerPort,
+            httpPort: httpPort2,
+            wsPort: wsPort2,
+            mqttPort: mqttPort2
+        })
+        broker3 = await startBroker({
+            name: 'broker3',
+            privateKey: broker3Key,
+            networkPort: networkPort3,
+            trackerPort,
+            httpPort: httpPort3,
+            wsPort: wsPort3,
+            mqttPort: mqttPort3
+        })
 
         client1 = createClient(wsPort1)
         client2 = createClient(wsPort2)

--- a/test/integration/new-storage/DeleteExpiredCmd.test.js
+++ b/test/integration/new-storage/DeleteExpiredCmd.test.js
@@ -62,7 +62,15 @@ describe('DeleteExpiredCmd', () => {
             keyspace,
         })
 
-        broker = await startBroker('broker', networkPort, trackerPort, httpPort, wsPort, null, true)
+        broker = await startBroker({
+            name: 'broker',
+            privateKey: '0xb198d9659173e0957d9cf8f4939d74efb9516465766f2952436103a5f31017b4',
+            networkPort,
+            trackerPort,
+            httpPort,
+            wsPort,
+            enableCassandra: true
+        })
         client = createClient(wsPort, {
             auth: {
                 apiKey: 'tester1-api-key'
@@ -96,7 +104,13 @@ describe('DeleteExpiredCmd', () => {
             await fixtures(cassandraClient, streamId, 2)
             await fixtures(cassandraClient, streamId, 3)
 
-            const deleteExpiredCmd = new DeleteExpiredCmd(formConfig('name', 0, 0, 0, 0, 0, true))
+            const deleteExpiredCmd = new DeleteExpiredCmd(formConfig({
+                name: 'name',
+                networkPort: 0,
+                trackerPort: 0,
+                privateKey: '0x09a0c3b1de507fe8655d6d042176c68f7905a77248b0c7c6671d2d94b1fda83e',
+                enableCassandra: true
+            }))
             await deleteExpiredCmd.run()
             await checkDBCount(cassandraClient, streamId, days)
         })

--- a/test/integration/new-storage/DeleteExpiredCmd.test.js
+++ b/test/integration/new-storage/DeleteExpiredCmd.test.js
@@ -2,16 +2,11 @@ const cassandra = require('cassandra-driver')
 const { TimeUuid } = require('cassandra-driver').types
 
 const DeleteExpiredCmd = require('../../../src/new-storage/DeleteExpiredCmd')
-const { startBroker, createClient, formConfig } = require('../../utils')
+const { createClient, formConfig } = require('../../utils')
 
 const contactPoints = ['127.0.0.1']
 const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
-
-const httpPort = 22341
-const wsPort = 22351
-const networkPort = 22361
-const trackerPort = 22370
 
 const fixtures = async (cassandraClient, streamId, daysAgo) => {
     const timestampDaysAgo = Date.now() - 1000 * 60 * 60 * 24 * daysAgo
@@ -48,12 +43,8 @@ const checkDBCount = async (cassandraClient, streamId, days) => {
 }
 
 describe('DeleteExpiredCmd', () => {
-    let broker
     let client
-
     let cassandraClient
-
-    let streamId
 
     beforeEach(async () => {
         cassandraClient = new cassandra.Client({
@@ -61,33 +52,16 @@ describe('DeleteExpiredCmd', () => {
             localDataCenter,
             keyspace,
         })
-
-        broker = await startBroker({
-            name: 'broker',
-            privateKey: '0xb198d9659173e0957d9cf8f4939d74efb9516465766f2952436103a5f31017b4',
-            networkPort,
-            trackerPort,
-            httpPort,
-            wsPort,
-            enableCassandra: true
-        })
-        client = createClient(wsPort, {
+        client = createClient(9999, {
             auth: {
                 apiKey: 'tester1-api-key'
             },
             orderMessages: false,
         })
-        await client.ensureConnected()
     })
 
     afterEach(async () => {
-        await broker.close()
-        await client.ensureDisconnected()
         await cassandraClient.shutdown()
-    })
-
-    afterAll(() => {
-        jest.restoreAllMocks()
     })
 
     const daysArray = [0, 1, 2, 3]
@@ -97,7 +71,7 @@ describe('DeleteExpiredCmd', () => {
                 name: 'DeleteExpiredCmd.test.js-' + Date.now(),
                 storageDays: days
             })
-            streamId = stream.id
+            const streamId = stream.id
 
             await fixtures(cassandraClient, streamId, 0)
             await fixtures(cassandraClient, streamId, 1)

--- a/test/integration/non-mqtt-connection-to-mqtt-adapter.test.js
+++ b/test/integration/non-mqtt-connection-to-mqtt-adapter.test.js
@@ -5,7 +5,7 @@ const { startTracker } = require('streamr-network')
 const { startBroker } = require('../utils')
 
 const trackerPort = 12411
-const brokerPort = 12412
+const networkPort = 12412
 const mqttPort = 12413
 
 describe('non-mqtt connection to MQTT adapter', () => {
@@ -21,7 +21,13 @@ describe('non-mqtt connection to MQTT adapter', () => {
             port: trackerPort,
             id: 'tracker'
         })
-        broker = await startBroker('broker', brokerPort, trackerPort, null, null, mqttPort, false)
+        broker = await startBroker({
+            name: 'broker',
+            privateKey: '0x4e850f1940b1901ca926f20e121f40ba6f6730eaae655d827f48eccf01e32f40',
+            networkPort,
+            trackerPort,
+            mqttPort
+        })
     })
 
     afterEach(async () => {

--- a/test/unit/new-storage/Bucket.test.js
+++ b/test/unit/new-storage/Bucket.test.js
@@ -61,18 +61,18 @@ describe('Bucket', () => {
         expect(bucket.isAlmostFull(0)).toBeTruthy()
     })
 
-    it('ttl is updated on each incrementBucket, if not isAlive switches to false', (done) => {
+    it('ttl is updated on each incrementBucket, if not isAlive switches to false', () => {
+        jest.useFakeTimers('modern').setSystemTime(0)
         const bucket = new Bucket('id', 'streamId', 0, 0, 0, new Date(), 3, 9, 1)
 
         expect(bucket.getId()).toEqual('id')
         expect(bucket.isAlive()).toBeTruthy()
 
-        setTimeout(() => {
-            expect(bucket.isAlive()).toBeFalsy()
-            bucket.incrementBucket(1, 3)
-            expect(bucket.isAlive()).toBeTruthy()
-            done()
-        }, 1000 + 1)
+        jest.advanceTimersByTime(1001)
+
+        expect(bucket.isAlive()).toBeFalsy()
+        bucket.incrementBucket(1, 3)
+        expect(bucket.isAlive()).toBeTruthy()
     })
 
     it('on each incrementBucket isStored becomes false', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -9,8 +9,18 @@ const DEFAULT_CLIENT_OPTIONS = {
     }
 }
 
-function formConfig(name, networkPort, trackerPort, httpPort, wsPort, mqttPort, enableCassandra, privateKeyFileName, certFileName,
-    generateWallet = true, ethereumPrivateKey) {
+function formConfig({
+    name,
+    networkPort,
+    trackerPort,
+    privateKey,
+    httpPort = null,
+    wsPort = null,
+    mqttPort = null,
+    enableCassandra = false,
+    privateKeyFileName = null,
+    certFileName = null
+}) {
     const adapters = []
     if (httpPort) {
         adapters.push({
@@ -47,8 +57,7 @@ function formConfig(name, networkPort, trackerPort, httpPort, wsPort, mqttPort, 
             isStorageNode: true
         },
         ethereum: {
-            privateKey: ethereumPrivateKey,
-            generateWallet
+            privateKey
         },
         location: {
             latitude: 60.19,


### PR DESCRIPTION
Make tests run faster & more predictabily.

- Make test helper utility `startBroker` and `formConfig` take object instead of long argument list.
- Remove unneeded broker from  _DeleteExpiredCmd.test.js_
- Make unit test _Bucket.test.js_ faster with fake timer.
- Make `Storage#store` return a Promise and await for it in `Storage.test.js` (as opposed to time-based `wait`). 