### PR TITLE
DeleteExpiredCmd: fixes

### DIFF
--- a/src/storage/DeleteExpiredCmd.js
+++ b/src/storage/DeleteExpiredCmd.js
@@ -73,7 +73,7 @@ class DeleteExpiredCmd {
                     return {
                         streamId: stream.streamId,
                         partition: stream.partition,
-                        storageDays: json.storageDays != null ? parseInt(json.storageDays): 365,
+                        storageDays: json.storageDays != null ? parseInt(json.storageDays) : 365,
                     }
                 }).catch((err) => logger.error(err))
             })

--- a/src/storage/DeleteExpiredCmd.js
+++ b/src/storage/DeleteExpiredCmd.js
@@ -53,7 +53,9 @@ class DeleteExpiredCmd {
 
     async _getStreams() {
         const query = 'SELECT DISTINCT stream_id, partition FROM bucket'
-        const resultSet = await this.cassandraClient.execute(query)
+        const resultSet = await this.cassandraClient.execute(query, [], {
+            fetchSize: 100000
+        })
         return resultSet.rows.map((row) => ({
             streamId: row.stream_id,
             partition: row.partition

--- a/src/storage/DeleteExpiredCmd.js
+++ b/src/storage/DeleteExpiredCmd.js
@@ -70,7 +70,7 @@ class DeleteExpiredCmd {
                     return {
                         streamId: stream.streamId,
                         partition: stream.partition,
-                        storageDays: parseInt(json.storageDays)
+                        storageDays: json.storageDays != null ? parseInt(json.storageDays): 365,
                     }
                 }).catch((err) => logger.error(err))
             })

--- a/src/storage/DeleteExpiredCmd.js
+++ b/src/storage/DeleteExpiredCmd.js
@@ -38,12 +38,15 @@ class DeleteExpiredCmd {
         logger.info(`Found ${streams.length} unique streams`)
 
         const streamsInfo = await this._fetchStreamsInfo(streams)
-        const expiredBuckets = await this._getExpiredBuckets(streamsInfo)
+        const potentialBuckets = await this._getPotentiallyExpiredBuckets(streamsInfo)
+        logger.info('Found %d potentially expired buckets', potentialBuckets.length)
 
+        const expiredBuckets = await this._filterExpiredBuckets(potentialBuckets)
         logger.info('Found %d expired buckets (total records %d and size %d MB)',
             expiredBuckets.length,
             totalNumOfRecords(expiredBuckets),
             totalSizeOfBuckets(expiredBuckets))
+
         if (!this.dryRun) {
             await this._deleteExpired(expiredBuckets)
         }
@@ -79,7 +82,7 @@ class DeleteExpiredCmd {
         return Promise.all(tasks)
     }
 
-    async _getExpiredBuckets(streamsInfo) {
+    async _getPotentiallyExpiredBuckets(streamsInfo) {
         const result = []
 
         const query = 'SELECT * FROM bucket WHERE stream_id = ? AND partition = ? AND date_create <= ?'
@@ -106,6 +109,31 @@ class DeleteExpiredCmd {
                             storageDays
                         })
                     })
+                }
+            })
+        })
+
+        await Promise.all(tasks)
+        return result
+    }
+
+    async _filterExpiredBuckets(potentialBuckets) {
+        const result = []
+
+        const query = 'SELECT MAX(ts) AS m FROM stream_data WHERE stream_id = ? AND partition = ? AND bucket_id = ?'
+
+        const tasks = potentialBuckets.filter(Boolean).map((bucket) => {
+            const { streamId, partition, bucketId, storageDays } = bucket
+            const timestampBefore = Date.now() - 1000 * 60 * 60 * 24 * storageDays
+            const params = [streamId, partition, bucketId]
+
+            return this.limit(async () => {
+                const resultSet = await this.cassandraClient.execute(query, params, {
+                    prepare: true,
+                }).catch((err) => logger.error(err))
+
+                if (resultSet.rows.length === 0 || resultSet.rows[0].m.getTime() < timestampBefore) {
+                    result.push(bucket)
                 }
             })
         })

--- a/test/integration/storage/DeleteExpiredCmd.test.js
+++ b/test/integration/storage/DeleteExpiredCmd.test.js
@@ -117,11 +117,11 @@ describe('DeleteExpiredCmd', () => {
         })
         const streamId = stream.id
 
-        const bucketId = await insertBucket(cassandraClient, streamId,Date.now() - 30 * DAY_IN_MS)
-        await insertData(cassandraClient, streamId, bucketId,Date.now() - 30 * DAY_IN_MS)
-        await insertData(cassandraClient, streamId, bucketId,Date.now() - 15 * DAY_IN_MS)
+        const bucketId = await insertBucket(cassandraClient, streamId, Date.now() - 30 * DAY_IN_MS)
+        await insertData(cassandraClient, streamId, bucketId, Date.now() - 30 * DAY_IN_MS)
+        await insertData(cassandraClient, streamId, bucketId, Date.now() - 15 * DAY_IN_MS)
         // prevents bucket from being deleted
-        await insertData(cassandraClient, streamId, bucketId,Date.now() - 3 * DAY_IN_MS)
+        await insertData(cassandraClient, streamId, bucketId, Date.now() - 3 * DAY_IN_MS)
 
         await deleteExpiredCmd.run()
         const counts = await checkDBCount(cassandraClient, streamId)


### PR DESCRIPTION
- (https://github.com/streamr-dev/broker/commit/dee09c2eb6e4c3db0d95e30490d79996f619544a) Maximum of 5000 unique streams could be found in production. Fixed the max limit to be 100k.
- (https://github.com/streamr-dev/broker/commit/d40889136efa430afc11dd6feab12b93bcabb14e) Use 365 storageDays default for streams that are no longer in MySQL but still in Cassandra.
- (https://github.com/streamr-dev/broker/commit/5256f1565165c649c3b8a048102ee95165c79d9f) Check last message timestamp of each expired bucket before deleting bucket and associated messages.
- (https://github.com/streamr-dev/broker/commit/87aa39103603796ba67ddf66e813975d38724358) Test for above scenario