### PR TITLE
NET-176: use jest-circus as test runner

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,18 +2,6 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
-    // All imported modules in your tests should be mocked automatically
-    // automock: false,
-
-    // Stop running tests after the first failure
-    // bail: false,
-
-    // Respect "browser" field in package.json when resolving modules
-    // browser: false,
-
-    // The directory where Jest should store its cached dependency information
-    // cacheDirectory: "/var/folders/75/slcz0ppn06l0_4nypfdn808w0000gp/T/jest_dy",
-
     // Automatically clear mock calls and instances between every test
     clearMocks: true,
 
@@ -23,158 +11,12 @@ module.exports = {
     // The directory where Jest should output its coverage files
     coverageDirectory: 'coverage',
 
-    // An array of regexp pattern strings used to skip coverage collection
-    // coveragePathIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
-
-    // A list of reporter names that Jest uses when writing coverage reports
-    // coverageReporters: [
-    //   "json",
-    //   "text",
-    //   "lcov",
-    //   "clover"
-    // ],
-
-    // An object that configures minimum threshold enforcement for coverage results
-    // coverageThreshold: null,
-
-    // Make calling deprecated APIs throw helpful error messages
-    // errorOnDeprecated: false,
-
-    // Force coverage collection from ignored files usin a array of glob patterns
-    // forceCoverageMatch: [],
-
-    // A path to a module which exports an async function that is triggered once before all test suites
-    // globalSetup: null,
-
-    // A path to a module which exports an async function that is triggered once after all test suites
-    // globalTeardown: null,
-
-    // A set of global variables that need to be available in all test environments
-    // globals: {},
-
-    // An array of directory names to be searched recursively up from the requiring module's location
-    // moduleDirectories: [
-    //   "node_modules"
-    // ],
-
-    // An array of file extensions your modules use
-    // moduleFileExtensions: [
-    //   "js",
-    //   "json",
-    //   "jsx",
-    //   "node"
-    // ],
-
-    // A map from regular expressions to module names that allow to stub out resources with a single module
-    // moduleNameMapper: {},
-
-    // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module
-    // loader
-    // modulePathIgnorePatterns: [],
-
-    // Activates notifications for test results
-    // notify: false,
-
-    // An enum that specifies notification mode. Requires { notify: true }
-    // notifyMode: "always",
-
-    // A preset that is used as a base for Jest's configuration
-    // preset: null,
-
-    // Run tests from one or more projects
-    // projects: null,
-
-    // Use this configuration option to add custom reporters to Jest
-    // reporters: undefined,
-
-    // Automatically reset mock state between every test
-    // resetMocks: false,
-
-    // Reset the module registry before running each individual test
-    // resetModules: false,
-
-    // A path to a custom resolver
-    // resolver: null,
-
-    // Automatically restore mock state between every test
-    // restoreMocks: false,
-
-    // The root directory that Jest should scan for tests and modules within
-    // rootDir: null,
-
-    // A list of paths to directories that Jest should use to search for files in
-    // roots: [
-    //   "<rootDir>"
-    // ],
-
-    // Allows you to use a custom runner instead of Jest's default test runner
-    // runner: "jest-runner",
-
-    // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
-
-    // The path to a module that runs some code to configure or set up the testing framework before each test
-    // setupTestFrameworkScriptFile: null,
-
-    // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-    // snapshotSerializers: [],
+    // This option allows use of a custom test runner
+    testRunner: 'jest-circus/runner',
 
     // The test environment that will be used for testing
     testEnvironment: 'node',
 
-    // Options that will be passed to the testEnvironment
-    // testEnvironmentOptions: {},
-
-    // Adds a location field to test results
-    // testLocationInResults: false,
-
-    // The glob patterns Jest uses to detect test files
-    // testMatch: [
-    //   "**/__tests__/**/*.js?(x)",
-    //   "**/?(*.)+(spec|test).js?(x)"
-    // ],
-
-    // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-    // testPathIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
-
-    // The regexp pattern Jest uses to detect test files
-    // testRegex: "",
-
-    // This option allows the use of a custom results processor
-    // testResultsProcessor: null,
-
-    // This option allows use of a custom test runner
-    // testRunner: "jasmine2",
-
-    // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-    // testURL: "about:blank",
-
-    // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
-    // timers: "real",
-
-    // A map from regular expressions to paths to transformers
-    // transform: null,
-
-    // An array of regexp pattern strings that are matched against all source file paths, matched files will skip
-    // transformation
-    // transformIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
-
-    // An array of regexp pattern strings that are matched against all modules before the module loader will
-    // automatically return a mock for them
-    // unmockedModulePathPatterns: undefined,
-
-    // Indicates whether each individual test should be reported during the run
-    // verbose: null,
-
-    // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-    // watchPathIgnorePatterns: [],
-
-    // Whether to use watchman for file crawling
-    // watchman: true,
+    // Default timeout of a test in milliseconds
+    testTimeout: 10000
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2820,6 +2820,12 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -5315,6 +5321,35 @@
             "path-key": "^3.0.0"
           }
         }
+      }
+    },
+    "jest-circus": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.6.3.tgz",
+      "integrity": "sha512-ACrpWZGcQMpbv13XbzRzpytEJlilP/Su0JtNCi5r/xLpOUhnaIJr8leYYpLEMgPFURZISEHrnnpmB54Q/UziPw==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/babel__traverse": "^7.0.4",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "expect": "^26.6.2",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2",
+        "stack-utils": "^2.0.2",
+        "throat": "^5.0.0"
       }
     },
     "jest-config": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "into-stream": "^6.0.0",
     "jest": "^26.6.3",
+    "jest-circus": "^26.6.3",
     "sinon": "^9.2.4",
     "stream-to-array": "^2.3.0",
     "streamr-test-utils": "^1.2.1",

--- a/test/integration/per-node-stream-metrics.test.js
+++ b/test/integration/per-node-stream-metrics.test.js
@@ -1,6 +1,4 @@
 const { startTracker } = require('streamr-network')
-const fetch = require('node-fetch')
-const { wait, waitForCondition } = require('streamr-test-utils')
 
 const { startBroker, createClient } = require('../utils')
 

--- a/test/integration/storage/BatchManager.test.js
+++ b/test/integration/storage/BatchManager.test.js
@@ -80,7 +80,7 @@ describe('BatchManager', () => {
         expect(Object.values(batchManager.pendingBatches)[0].streamMessages).toHaveLength(10)
     })
 
-    test('pendingBatches are inserted', async (done) => {
+    test('pendingBatches are inserted', (done) => {
         const msg = buildMsg(streamId, 0, 1000, 0, 'publisher1')
         batchManager.store(bucketId, msg)
 

--- a/test/integration/websocket-server.test.js
+++ b/test/integration/websocket-server.test.js
@@ -14,23 +14,27 @@ describe('websocket server', () => {
         await broker.close()
     })
 
-    it('receives unencrypted connections', async (done) => {
-        broker = await startBroker({
+    it('receives unencrypted connections', (done) => {
+        startBroker({
             name: 'broker',
             privateKey: '0xf3b269f5d8066bcf23a384937c0cd693cfbb8ff90a1055d4e47047150f5482c4',
             networkPort: 12345,
             trackerPort: 666,
             wsPort: 12346
+        }).then((newBroker) => {
+            broker = newBroker
+            ws = new WebSocket(getWsUrl(12346))
+            ws.on('open', () => {
+                done()
+            })
+            ws.on('error', (err) => {
+                done(err)
+            })
         })
-        ws = new WebSocket(getWsUrl(12346))
-        ws.on('open', async () => {
-            done()
-        })
-        ws.on('error', (err) => done(err))
     })
 
-    it('receives encrypted connections', async (done) => {
-        broker = await startBroker({
+    it('receives encrypted connections', (done) => {
+        startBroker({
             name: 'broker',
             privateKey: '0xf3b269f5d8066bcf23a384937c0cd693cfbb8ff90a1055d4e47047150f5482c4',
             networkPort: 12345,
@@ -38,14 +42,18 @@ describe('websocket server', () => {
             wsPort: 12346,
             privateKeyFileName: 'test/fixtures/key.pem',
             certFileName: 'test/fixtures/cert.pem'
+        }).then((newBroker) => {
+            broker = newBroker
+            ws = new WebSocket(getWsUrl(12346, true), {
+                rejectUnauthorized: false // needed to accept self-signed certificate
+            })
+            ws.on('open', () => {
+                done()
+            })
+            ws.on('error', (err) => {
+                done(err)
+            })
         })
-        ws = new WebSocket(getWsUrl(12346, true), {
-            rejectUnauthorized: false // needed to accept self-signed certificate
-        })
-        ws.on('open', async () => {
-            done()
-        })
-        ws.on('error', (err) => done(err))
     })
 
     describe('rejections', () => {


### PR DESCRIPTION
Use `jest-circus` as test runner. Seems to resolve this issue https://github.com/facebook/jest/issues/9527 and the issue where a rejecting promise returned from `beforeAll` does not prevent test cases from being run. I had to fix tests cases that have both `done()` and `async` in use in them because circus throws an error if using both in a test. I also increased default test timeout to 10 seconds, as it seems 5 seconds is not enough in many cases.