### PR TITLE
Replace 127.0.0.1 with STREAMR_DOCKER_DEV_HOST in tests

### DIFF
--- a/test/integration/per-node-stream-metrics.test.js
+++ b/test/integration/per-node-stream-metrics.test.js
@@ -1,6 +1,6 @@
 const { startTracker } = require('streamr-network')
 
-const { startBroker, createClient } = require('../utils')
+const { startBroker, createClient, STREAMR_DOCKER_DEV_HOST } = require('../utils')
 
 const httpPort1 = 12741
 const wsPort1 = 12751
@@ -45,7 +45,7 @@ describe('metricsStream', () => {
                 perNodeMetrics: {
                     enabled: true,
                     wsUrl: 'ws://127.0.0.1:' + wsPort1 + '/api/v1/ws',
-                    httpUrl: 'http://localhost/api/v1'
+                    httpUrl: `http://${STREAMR_DOCKER_DEV_HOST}/api/v1`
                 }
             }
         })

--- a/test/integration/resends-cancelled-on-client-disconnect.test.js
+++ b/test/integration/resends-cancelled-on-client-disconnect.test.js
@@ -5,7 +5,7 @@ const { waitForCondition } = require('streamr-test-utils')
 const ws = require('uWebSockets.js')
 
 const WebsocketServer = require('../../src/websocket/WebsocketServer')
-const { createClient } = require('../utils')
+const { createClient, STREAMR_DOCKER_DEV_HOST } = require('../utils')
 const StreamFetcher = require('../../src/StreamFetcher')
 const Publisher = require('../../src/Publisher')
 const SubscriptionManager = require('../../src/SubscriptionManager')
@@ -70,7 +70,7 @@ describe('resend cancellation', () => {
             ws.App(),
             wsPort,
             networkNode,
-            new StreamFetcher('http://localhost:8081/streamr-core'),
+            new StreamFetcher(`http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core`),
             new Publisher(networkNode, {}, metricsContext),
             metricsContext,
             new SubscriptionManager(networkNode)

--- a/test/integration/storage/BatchManager.test.js
+++ b/test/integration/storage/BatchManager.test.js
@@ -3,9 +3,10 @@ const { TimeUuid } = require('cassandra-driver').types
 const { StreamMessage, MessageIDStrict } = require('streamr-network').Protocol.MessageLayer
 const { waitForCondition } = require('streamr-test-utils')
 
+const { STREAMR_DOCKER_DEV_HOST } = require('../../utils')
 const BatchManager = require('../../../src/storage/BatchManager')
 
-const contactPoints = ['127.0.0.1']
+const contactPoints = [STREAMR_DOCKER_DEV_HOST]
 const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 

--- a/test/integration/storage/BucketManager.test.js
+++ b/test/integration/storage/BucketManager.test.js
@@ -3,8 +3,9 @@ const { waitForCondition } = require('streamr-test-utils')
 const { TimeUuid } = require('cassandra-driver').types
 
 const BucketManager = require('../../../src/storage/BucketManager')
+const { STREAMR_DOCKER_DEV_HOST } = require('../../utils')
 
-const contactPoints = ['127.0.0.1']
+const contactPoints = [STREAMR_DOCKER_DEV_HOST]
 const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 

--- a/test/integration/storage/DeleteExpiredCmd.test.js
+++ b/test/integration/storage/DeleteExpiredCmd.test.js
@@ -2,9 +2,9 @@ const cassandra = require('cassandra-driver')
 const { TimeUuid } = require('cassandra-driver').types
 
 const DeleteExpiredCmd = require('../../../src/storage/DeleteExpiredCmd')
-const { createClient } = require('../../utils')
+const { createClient, STREAMR_DOCKER_DEV_HOST } = require('../../utils')
 
-const contactPoints = ['127.0.0.1']
+const contactPoints = [STREAMR_DOCKER_DEV_HOST]
 const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 
@@ -64,10 +64,10 @@ describe('DeleteExpiredCmd', () => {
             orderMessages: false,
         })
         deleteExpiredCmd = new DeleteExpiredCmd({
-            streamrBaseUrl: 'http://localhost:8081/streamr-core',
+            streamrBaseUrl: `http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core`,
             cassandraUsername: '',
             cassandraPassword: '',
-            cassandraHosts: ['localhost'],
+            cassandraHosts: [STREAMR_DOCKER_DEV_HOST],
             cassandraDatacenter: 'datacenter1',
             cassandraKeyspace: 'streamr_dev_v2',
             dryRun: false

--- a/test/integration/storage/Storage.test.js
+++ b/test/integration/storage/Storage.test.js
@@ -3,8 +3,9 @@ const toArray = require('stream-to-array')
 const { StreamMessage, MessageIDStrict } = require('streamr-network').Protocol.MessageLayer
 
 const { startCassandraStorage } = require('../../../src/storage/Storage')
+const { STREAMR_DOCKER_DEV_HOST } = require('../../utils')
 
-const contactPoints = ['127.0.0.1']
+const contactPoints = [STREAMR_DOCKER_DEV_HOST]
 const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -9,6 +9,8 @@ const DEFAULT_CLIENT_OPTIONS = {
     }
 }
 
+const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
+
 function formConfig({
     name,
     networkPort,
@@ -20,7 +22,7 @@ function formConfig({
     enableCassandra = false,
     privateKeyFileName = null,
     certFileName = null,
-    streamrUrl = 'http://localhost:8081/streamr-core',
+    streamrUrl = `http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core`,
     reporting = false
 }) {
     const adapters = []
@@ -66,7 +68,7 @@ function formConfig({
             }
         },
         cassandra: enableCassandra ? {
-            hosts: ['localhost'],
+            hosts: [STREAMR_DOCKER_DEV_HOST],
             datacenter: 'datacenter1',
             username: '',
             password: '',
@@ -102,7 +104,7 @@ function getWsUrlWithControlAndMessageLayerVersions(port, ssl = false, controlLa
 function createClient(wsPort, clientOptions = DEFAULT_CLIENT_OPTIONS) {
     return new StreamrClient({
         url: getWsUrl(wsPort),
-        restUrl: 'http://localhost:8081/streamr-core/api/v1',
+        restUrl: `http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core/api/v1`,
         ...clientOptions,
     })
 }
@@ -117,6 +119,7 @@ function createMqttClient(mqttPort = 9000, host = 'localhost', apiKey = 'tester1
 }
 
 module.exports = {
+    STREAMR_DOCKER_DEV_HOST,
     formConfig,
     startBroker,
     createClient,


### PR DESCRIPTION
Instead of having hostname of Docker `127.0.0.1`  hardcoded into the test suite, have a constant `STREAMR_DOCKER_DEV_HOST` that can be pointed to any arbitrary Docker instance via environment variable. Useful if you want to run Docker on a separate machine. Default behaviour (when no env variable given) is to use `127.0.0.1` as before.