### PR TITLE
Use Buster slim Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM node:14-buster as build
 WORKDIR /usr/src/broker
 COPY . .
-
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends cmake \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
+#RUN apt-get update && apt-get install --assume-yes --no-install-recommends cmake \
+#	&& apt-get clean \
+#	&& rm -rf /var/lib/apt/lists/*
 RUN npm ci --only=production
 
 FROM node:14-buster-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@ FROM node:14-buster as build
 WORKDIR /usr/src/broker
 COPY . .
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends cmake
-
-RUN node --version
-RUN npm --version
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends cmake \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 RUN npm ci --only=production
 
-FROM node:14-buster
+FROM node:14-buster-slim
 
 COPY --from=build /usr/src/broker /usr/src/broker
 WORKDIR /usr/src/broker


### PR DESCRIPTION
- Clean up after install
- Remove node version print (it's cached anyway)