### PR TITLE
NET-247: MQTT authentication using private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ https://semver.org/. Files package.json and package-lock.json will be automatica
 For production version of the Streamr API refer to [API Explorer](https://api-explorer.streamr.com).
 
 ### Special considerations for using MQTT adapter
-- For authentication put API_KEY in the password connection field
+- For authentication put private key in the password connection field
 - MQTT clients can send plain text, but their payload will be transformed to a JSON object accordingly:
 `{"mqttPayload":"ORIGINAL_PLAINTEXT_PAYLOAD}`
 
 #### Error handling
-- If API_KEY is not correct, client will receive "Connection refused, bad user name or password" (returnCode: 4)
+- If private key is not correct, client will receive "Connection refused, bad user name or password" (returnCode: 4)
 - If stream is not found, client will receive "Connection refused, not authorized" (returnCode: 5)

--- a/test/integration/mqtt-error-handling.test.js
+++ b/test/integration/mqtt-error-handling.test.js
@@ -89,9 +89,9 @@ describe('MQTT error handling', () => {
         })
     })
 
-    it('test not valid api key', (done) => {
+    it('test not valid private key', (done) => {
         setUpBroker(false).then(() => {
-            mqttClient = createMqttClient(mqttPort, 'localhost', 'NOT_VALID_KEY')
+            mqttClient = createMqttClient(mqttPort, 'localhost', 'NOT_VALID_PRIVATE_KEY')
             mqttClient.on('error', (err) => {
                 expect(err.message).toEqual('Connection refused: Bad username or password')
                 mqttClient.end(true)

--- a/test/integration/mqtt.test.js
+++ b/test/integration/mqtt.test.js
@@ -247,9 +247,6 @@ describe('mqtt: end-to-end', () => {
         const client3Messages = []
         const client4Messages = []
 
-        await freshStream1.grantPermission('stream_get', 'tester2@streamr.com')
-        await freshStream1.grantPermission('stream_subscribe', 'tester2@streamr.com')
-
         await waitForCondition(() => mqttClient1.connected)
 
         await mqttClient1.subscribe(freshStream1.id)

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,6 +12,8 @@ const DEFAULT_CLIENT_OPTIONS = {
     }
 }
 
+const TESTER1_PRIVATE_KEY = '8b5e348b8e553c3b0491f68c50b203d02d3674d49abd1a95090d6c9cfcf64a08'
+
 const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
 const API_URL = `http://${STREAMR_DOCKER_DEV_HOST}/api/v1`
 
@@ -116,12 +118,12 @@ function createClient(wsPort, clientOptions = DEFAULT_CLIENT_OPTIONS) {
     })
 }
 
-function createMqttClient(mqttPort = 9000, host = 'localhost', apiKey = 'tester1-api-key') {
+function createMqttClient(mqttPort = 9000, host = 'localhost', privateKey = TESTER1_PRIVATE_KEY) {
     return mqtt.connect({
         hostname: host,
         port: mqttPort,
         username: '',
-        password: apiKey
+        password: privateKey
     })
 }
 


### PR DESCRIPTION
**Breaking change:** Change the authentication to use private key: read the "password" field as we currently do, but expect that the content is a private key, not an API key.

