### PR TITLE
Tidy DataQueryEndpoints test

### DIFF
--- a/src/http/DataQueryEndpoints.js
+++ b/src/http/DataQueryEndpoints.js
@@ -23,28 +23,35 @@ const onRow = (res, unicastMessage, delimiter, format = 'object', version, metri
 }
 
 const streamData = (res, stream, format, version, metrics) => {
-    let delimiter = ''
-    stream.on('data', (row) => {
-        // first row
-        if (delimiter === '') {
-            onStarted(res)
-        }
-        onRow(res, row, delimiter, format, version, metrics)
-        delimiter = ','
-    })
-    stream.on('end', () => {
-        if (delimiter === '') {
-            onStarted(res)
-        }
-        res.write(']')
-        res.end()
-    })
-    stream.on('error', (err) => {
+    try {
+        let delimiter = ''
+        stream.on('data', (row) => {
+            // first row
+            if (delimiter === '') {
+                onStarted(res)
+            }
+            onRow(res, row, delimiter, format, version, metrics)
+            delimiter = ','
+        })
+        stream.on('end', () => {
+            if (delimiter === '') {
+                onStarted(res)
+            }
+            res.write(']')
+            res.end()
+        })
+        stream.on('error', (err) => {
+            logger.error(err)
+            res.status(500).send({
+                error: 'Failed to fetch data!'
+            })
+        })
+    } catch (err) {
         logger.error(err)
         res.status(500).send({
             error: 'Failed to fetch data!'
         })
-    })
+    }
 }
 
 function parseIntIfExists(x) {


### PR DESCRIPTION
Fixes distracting and unnecessary `TypeError` issues reported in tests.

![image](https://user-images.githubusercontent.com/43438/115301461-3b93aa00-a12f-11eb-9f58-4b3eddc47612.png)

Also converts the `supertest` tests to use `async`/`await` instead of Jest's `done` callback.