### PR TITLE
NET-242: remove gap filling from WsEndpoint

### DIFF
--- a/src/Stream.js
+++ b/src/Stream.js
@@ -1,29 +1,10 @@
-const { Utils } = require('streamr-network').Protocol
-
-const logger = require('./helpers/logger')('streamr:Stream')
-
 module.exports = class Stream {
-    constructor(id, partition, name, msgHandler, gapHandler) {
+    constructor(id, partition, name) {
         this.id = id
         this.name = name
         this.partition = partition
         this.state = 'init'
         this.connections = []
-        this.orderingUtil = new Utils.OrderingUtil(id, partition, msgHandler, (...args) => {
-            gapHandler(id, partition, ...args)
-        })
-        this.orderingUtil.on('error', (err) => {
-            // attach error handler in attempt to avoid uncaught exceptions
-            logger.warn(err)
-        })
-    }
-
-    passToOrderingUtil(streamMessage) {
-        this.orderingUtil.add(streamMessage)
-    }
-
-    clearOrderingUtil() {
-        this.orderingUtil.clearGaps()
     }
 
     addConnection(connection) {

--- a/src/StreamStateManager.js
+++ b/src/StreamStateManager.js
@@ -6,11 +6,9 @@ function getStreamLookupKey(streamId, streamPartition) {
 }
 
 module.exports = class StreamStateManager {
-    constructor(msgHandler, gapHander) {
+    constructor() {
         this._streams = {}
         this._timeouts = {}
-        this.msgHandler = msgHandler
-        this.gapHandler = gapHander
     }
 
     getOrCreate(streamId, streamPartition, name = '') {
@@ -44,7 +42,7 @@ module.exports = class StreamStateManager {
             throw new Error(`stream already exists for ${key}`)
         }
 
-        const stream = new Stream(streamId, streamPartition, name, this.msgHandler, this.gapHandler)
+        const stream = new Stream(streamId, streamPartition, name)
         this._streams[key] = stream
 
         /*
@@ -85,9 +83,6 @@ module.exports = class StreamStateManager {
     }
 
     close() {
-        Object.values(this._streams).forEach((stream) => {
-            stream.clearOrderingUtil()
-        })
         Object.values(this._timeouts).forEach((timeout) => {
             clearTimeout(timeout)
         })

--- a/src/websocket/RequestHandlers.ts
+++ b/src/websocket/RequestHandlers.ts
@@ -44,25 +44,8 @@ export class RequestHandlers {
             [ControlLayer.ControlMessage.TYPES.ResendRangeRequest]: this.handleResendRangeRequest,
             [ControlLayer.ControlMessage.TYPES.PublishRequest]: this.handlePublishRequest,
         }
-        this.streams = new StreamStateManager(
-            this._broadcastMessage.bind(this),
-            (streamId: Todo, streamPartition: Todo, from: Todo, to: Todo, publisherId: Todo, msgChainId: Todo) => {
-                this.networkNode.requestResendRange(
-                    streamId,
-                    streamPartition,
-                    uuidv4(),
-                    from.timestamp,
-                    from.sequenceNumber,
-                    to.timestamp,
-                    to.sequenceNumber,
-                    publisherId,
-                    msgChainId
-                ).on('data', (unicastMessage: Todo) => {
-                    this._handleStreamMessage(unicastMessage.streamMessage)
-                })
-            }
-        )
-        this.networkNode.addMessageListener(this._handleStreamMessage.bind(this))
+        this.streams = new StreamStateManager()
+        this.networkNode.addMessageListener(this._broadcastMessage.bind(this))
     }
 
     getInstance(messageType: Todo): RequestHandler|undefined {
@@ -356,17 +339,6 @@ export class RequestHandlers {
             }
         } else {
             await this.streamFetcher.checkPermission(request.streamId, request.sessionToken, 'stream_subscribe')
-        }
-    }
-
-    _handleStreamMessage(streamMessage: Todo) {
-        const streamId = streamMessage.getStreamId()
-        const streamPartition = streamMessage.getStreamPartition()
-        const stream = this.streams.get(streamId, streamPartition)
-        if (stream) {
-            setImmediate(() => stream.passToOrderingUtil(streamMessage), 0)
-        } else {
-            logger.debug('_handleStreamMessage: stream "%s:%d" not found', streamId, streamPartition)
         }
     }
 


### PR DESCRIPTION
Old versions of `streamr-client-javascript` did not have gap filling functionality. Due to this historical reason, we used to do gap filling on broker. These versions are now long gone, so remove gap filling.