### PR TITLE
Fix flakey tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   "main": "bin/broker.js",
   "scripts": {
     "prepare": "tsc -p tsconfig-build.json",
-    "test": "eslint . && jest",
+    "test": "eslint . && jest test/unit test/integration && npm run test-sequential",
     "build": "tsc -p tsconfig-build.json --incremental",
     "test-unit": "jest test/unit",
-    "test-integration": "jest --forceExit test/integration",
+    "test-sequential": "jest --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
+    "test-integration": "jest --forceExit test/integration && npm run test-sequential",
     "eslint": "eslint ."
   },
   "author": "Streamr Network AG <contact@streamr.com>",

--- a/test/integration/SubscriptionManager.test.ts
+++ b/test/integration/SubscriptionManager.test.ts
@@ -3,7 +3,7 @@ import StreamrClient, { Stream } from 'streamr-client'
 import { startTracker } from 'streamr-network'
 import { wait, waitForCondition } from 'streamr-test-utils'
 import { Todo } from '../types'
-import { startBroker, createMockUser, createClient, createMqttClient } from '../utils'
+import { startBroker, fastPrivateKey, createClient, createMqttClient } from '../utils'
 
 const httpPort1 = 13381
 const httpPort2 = 13382
@@ -19,7 +19,7 @@ describe('SubscriptionManager', () => {
     let tracker: Todo
     let broker1: Todo
     let broker2: Todo
-    const mockUser = createMockUser()
+    const privateKey = fastPrivateKey()
     let client1: StreamrClient
     let client2: StreamrClient
     let freshStream1: Stream
@@ -55,11 +55,11 @@ describe('SubscriptionManager', () => {
 
         await wait(2000)
 
-        client1 = createClient(wsPort1, mockUser.privateKey)
-        client2 = createClient(wsPort2, mockUser.privateKey)
+        client1 = createClient(wsPort1, privateKey)
+        client2 = createClient(wsPort2, privateKey)
 
-        mqttClient1 = createMqttClient(mqttPort1, 'localhost', mockUser.privateKey)
-        mqttClient2 = createMqttClient(mqttPort2, 'localhost', mockUser.privateKey)
+        mqttClient1 = createMqttClient(mqttPort1, 'localhost', privateKey)
+        mqttClient2 = createMqttClient(mqttPort2, 'localhost', privateKey)
 
         freshStream1 = await client1.createStream({
             name: 'SubscriptionManager.test.js-' + Date.now()

--- a/test/integration/local-propagation.test.ts
+++ b/test/integration/local-propagation.test.ts
@@ -3,7 +3,7 @@ import StreamrClient, { Stream } from 'streamr-client'
 import { startTracker } from 'streamr-network'
 import { wait, waitForCondition } from 'streamr-test-utils'
 import { Todo } from '../types'
-import { startBroker, createMockUser, createClient, createMqttClient } from '../utils'
+import { startBroker, fastPrivateKey, createClient, createMqttClient } from '../utils'
 
 const trackerPort = 17711
 const httpPort = 17712
@@ -14,7 +14,7 @@ const mqttPort = 17751
 describe('local propagation', () => {
     let tracker: Todo
     let broker: Todo
-    const mockUser = createMockUser()
+    const privateKey = fastPrivateKey()
     let client1: StreamrClient
     let client2: StreamrClient
     let freshStream: Stream
@@ -39,11 +39,11 @@ describe('local propagation', () => {
             mqttPort
         })
 
-        client1 = createClient(wsPort, mockUser.privateKey)
-        client2 = createClient(wsPort, mockUser.privateKey)
+        client1 = createClient(wsPort, privateKey)
+        client2 = createClient(wsPort, privateKey)
 
-        mqttClient1 = createMqttClient(mqttPort, 'localhost', mockUser.privateKey)
-        mqttClient2 = createMqttClient(mqttPort, 'localhost', mockUser.privateKey)
+        mqttClient1 = createMqttClient(mqttPort, 'localhost', privateKey)
+        mqttClient2 = createMqttClient(mqttPort, 'localhost', privateKey)
 
         freshStream = await client1.createStream({
             name: 'local-propagation.test.js-' + Date.now()

--- a/test/integration/mqtt.test.ts
+++ b/test/integration/mqtt.test.ts
@@ -3,7 +3,7 @@ import StreamrClient, { Stream } from 'streamr-client'
 import { startTracker } from 'streamr-network'
 import { wait, waitForCondition } from 'streamr-test-utils'
 import { Todo } from '../types'
-import { startBroker, createMockUser, createClient, createMqttClient } from '../utils'
+import { startBroker, fastPrivateKey, createClient, createMqttClient } from '../utils'
 
 const httpPort1 = 12381
 const httpPort2 = 12382
@@ -27,7 +27,7 @@ describe('mqtt: end-to-end', () => {
     let broker1: Todo
     let broker2: Todo
     let broker3: Todo
-    const mockUser = createMockUser()
+    const privateKey = fastPrivateKey()
     let client1: StreamrClient
     let client2: StreamrClient
     let client3: StreamrClient
@@ -70,13 +70,13 @@ describe('mqtt: end-to-end', () => {
             mqttPort: mqttPort3
         })
 
-        client1 = createClient(wsPort1, mockUser.privateKey)
-        client2 = createClient(wsPort2, mockUser.privateKey)
-        client3 = createClient(wsPort3, mockUser.privateKey)
+        client1 = createClient(wsPort1, privateKey)
+        client2 = createClient(wsPort2, privateKey)
+        client3 = createClient(wsPort3, privateKey)
 
-        mqttClient1 = createMqttClient(mqttPort1, 'localhost', mockUser.privateKey)
-        mqttClient2 = createMqttClient(mqttPort2, 'localhost', mockUser.privateKey)
-        mqttClient3 = createMqttClient(mqttPort3, 'localhost', mockUser.privateKey)
+        mqttClient1 = createMqttClient(mqttPort1, 'localhost', privateKey)
+        mqttClient2 = createMqttClient(mqttPort2, 'localhost', privateKey)
+        mqttClient3 = createMqttClient(mqttPort3, 'localhost', privateKey)
 
         freshStream1 = await client1.createStream({
             name: 'mqtt.test.js-' + Date.now()

--- a/test/integration/ping-pong.test.ts
+++ b/test/integration/ping-pong.test.ts
@@ -28,6 +28,9 @@ describe('ping-pong test between broker and clients', () => {
             port: trackerPort,
             id: 'tracker'
         })
+    })
+
+    beforeEach(async () => {
         networkNode = await startNetworkNode({
             host: '127.0.0.1',
             port: networkNodePort,
@@ -45,23 +48,30 @@ describe('ping-pong test between broker and clients', () => {
             metricsContext,
             new SubscriptionManager(networkNode)
         )
+    })
 
+    beforeEach(async () => {
         client1 = createClient(wsPort)
-        await client1.ensureConnected()
-
         client2 = createClient(wsPort)
-        await client2.ensureConnected()
-
         client3 = createClient(wsPort)
-        await client3.ensureConnected()
 
+        await Promise.all([
+            client1.ensureConnected(),
+            client2.ensureConnected(),
+            client3.ensureConnected()
+        ])
+    })
+
+    beforeEach(async () => {
         await waitForCondition(() => websocketServer.connections.size === 3)
     })
 
     afterEach(async () => {
-        await client1.ensureDisconnected()
-        await client2.ensureDisconnected()
-        await client3.ensureDisconnected()
+        await Promise.all([
+            client1.ensureDisconnected(),
+            client2.ensureDisconnected(),
+            client3.ensureDisconnected()
+        ])
 
         await tracker.stop()
         await networkNode.stop()

--- a/test/integration/storage/StorageConfig.test.ts
+++ b/test/integration/storage/StorageConfig.test.ts
@@ -5,11 +5,11 @@ import { Protocol, startTracker } from 'streamr-network'
 import cassandra from 'cassandra-driver'
 import { Wallet } from 'ethers'
 import { waitForCondition } from 'streamr-test-utils'
-import { 
+import {
     startBroker,
     createClient,
     StorageAssignmentEventManager,
-    waitForStreamPersistedInStorageNode, 
+    waitForStreamPersistedInStorageNode,
     STREAMR_DOCKER_DEV_HOST
 } from '../../utils'
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import StreamrClient, { Stream, StreamrClientOptions } from 'streamr-client'
 import mqtt from 'async-mqtt'
 import fetch from 'node-fetch'
@@ -104,9 +105,17 @@ export function getWsUrlWithControlAndMessageLayerVersions(port: number, ssl = f
     return `${ssl ? 'wss' : 'ws'}://127.0.0.1:${port}/api/v1/ws?controlLayerVersion=${controlLayerVersion}&messageLayerVersion=${messageLayerVersion}`
 }
 
+// generates a private key
+// equivalent to Wallet.createRandom().privateKey but much faster
+// the slow part seems to be deriving the address from the key so if you can avoid this, just use
+// fastPrivateKey instead of createMockUser
+export function fastPrivateKey() {
+    return `0x${crypto.randomBytes(32).toString('hex')}`
+}
+
 export const createMockUser = () => Wallet.createRandom()
 
-export function createClient(wsPort: number, privateKey = createMockUser().privateKey, clientOptions?: StreamrClientOptions) {
+export function createClient(wsPort: number, privateKey = fastPrivateKey(), clientOptions?: StreamrClientOptions) {
     return new StreamrClient({
         auth: {
             privateKey
@@ -117,7 +126,7 @@ export function createClient(wsPort: number, privateKey = createMockUser().priva
     })
 }
 
-export function createMqttClient(mqttPort = 9000, host = 'localhost', privateKey = createMockUser().privateKey) {
+export function createMqttClient(mqttPort = 9000, host = 'localhost', privateKey = fastPrivateKey()) {
     return mqtt.connect({
         hostname: host,
         port: mqttPort,


### PR DESCRIPTION
Was having trouble with running the `test/integration/storage` tests in parallel.

They would pass when run in series, but not when run in parallel. Seems the `DeleteExpiredCmd` test was interfering with the other storage tests. Not sure how this ever worked, but moving this test out so it runs isolated after all the other tests seems to work 👍 .

Also noticed `test/integration/ping-pong.test.ts` test was sometimes failing, timing out in `beforeEach`. Didn't seem to be a logic issue, was just taking too long. Rather than just increase the timeout, I opted for making the setup run differently:

1. Some of the async tasks now run in parallel
2. Steps that were slow are wrapped in own `beforeEach`. This effectively increases the timeout, but if there's a problem it makes it clear exactly which async step timed out.
3. Switched `privateKey` generation from `Wallet.createRandom` to `crypto.randomBytes(32)` where possible. Changed this across test suite. This can greatly improve the test speed, `Wallet.createRandom` is very slow.

Difference in tests can be significant, surprisingly so:

## Before: (11.8 s)

```
 PASS  test/integration/ping-pong.test.ts (11.801 s)
  ping-pong test between broker and clients
    ✓ websocketServer sends pings and receives pongs from clients (4869 ms)
    ✓ websocketServer closes connections, which are not replying with pong (4659 ms)
```

## After: (4.3 s)

```
 PASS  test/integration/ping-pong.test.ts (4.3 s)
  ping-pong test between broker and clients
    ✓ websocketServer sends pings and receives pongs from clients (1152 ms)
    ✓ websocketServer closes connections, which are not replying with pong (995 ms)
```

Computing the associated address from the private key appears to be the bottleneck. If you run `ethers.utils.computeAddress` on `crypto.randomBytes(32)` the speed is about the same as `Wallet.createRandom`. 
Note that this blocks the entire JS event loop while computation occurs.

Many tests only need the private key, no need to compute the address. Where address is not needed, use `fastPrivateKey()` from `test/utils.ts`, instead of `createMockUser().privateKey`.