### PR TITLE
Update to streamr-network 24.1.10, fix more flakey tests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6939,23 +6939,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+          "bundled": true
         },
         "base64-js": {
           "version": "1.5.1",
-          "resolved": false,
-          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+          "bundled": true
         },
         "buffer": {
           "version": "5.7.1",
-          "resolved": false,
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "bundled": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -6963,140 +6959,115 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "resolved": false,
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "bundled": true
         },
         "decompress-response": {
           "version": "4.2.1",
-          "resolved": false,
-          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "bundled": true,
           "requires": {
             "mimic-response": "^2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+          "bundled": true
         },
         "end-of-stream": {
           "version": "1.4.4",
-          "resolved": false,
-          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+          "bundled": true,
           "requires": {
             "once": "^1.4.0"
           }
         },
         "expand-template": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+          "bundled": true
         },
         "fs-constants": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+          "bundled": true
         },
         "github-from-package": {
           "version": "0.0.0",
-          "resolved": false,
-          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+          "bundled": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+          "bundled": true
         },
         "ieee754": {
           "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+          "bundled": true
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "bundled": true
         },
         "mimic-response": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+          "bundled": true
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": false,
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "bundled": true
         },
         "mkdirp-classic": {
           "version": "0.5.3",
-          "resolved": false,
-          "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+          "bundled": true
         },
         "napi-build-utils": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+          "bundled": true
         },
         "node-abi": {
           "version": "2.19.3",
-          "resolved": false,
-          "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+          "bundled": true,
           "requires": {
             "semver": "^5.4.1"
           }
         },
         "noop-logger": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+          "bundled": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -7106,8 +7077,7 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": false,
-              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+              "bundled": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -7115,8 +7085,7 @@
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": false,
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "bundled": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -7132,26 +7101,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "prebuild-install": {
           "version": "5.3.6",
-          "resolved": false,
-          "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+          "bundled": true,
           "requires": {
             "detect-libc": "^1.0.3",
             "expand-template": "^2.0.3",
@@ -7172,13 +7137,11 @@
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+          "bundled": true
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "bundled": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -7186,8 +7149,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "bundled": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -7197,8 +7159,7 @@
         },
         "readable-stream": {
           "version": "2.3.7",
-          "resolved": false,
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "bundled": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -7211,33 +7172,27 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "bundled": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+          "bundled": true
         },
         "simple-concat": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+          "bundled": true
         },
         "simple-get": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+          "bundled": true,
           "requires": {
             "decompress-response": "^4.2.0",
             "once": "^1.3.1",
@@ -7246,8 +7201,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7256,29 +7210,25 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "bundled": true
         },
         "tar-fs": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+          "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "mkdirp-classic": "^0.5.2",
@@ -7288,8 +7238,7 @@
         },
         "tar-stream": {
           "version": "2.1.4",
-          "resolved": false,
-          "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+          "bundled": true,
           "requires": {
             "bl": "^4.0.3",
             "end-of-stream": "^1.4.1",
@@ -7300,8 +7249,7 @@
           "dependencies": {
             "bl": {
               "version": "4.0.3",
-              "resolved": false,
-              "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+              "bundled": true,
               "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -7310,8 +7258,7 @@
             },
             "readable-stream": {
               "version": "3.6.0",
-              "resolved": false,
-              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "bundled": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -7322,34 +7269,29 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": false,
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "bundled": true
         },
         "which-pm-runs": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "bundled": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         }
       }
     },
@@ -9475,9 +9417,9 @@
       }
     },
     "streamr-network": {
-      "version": "24.1.9",
-      "resolved": "https://registry.npmjs.org/streamr-network/-/streamr-network-24.1.9.tgz",
-      "integrity": "sha512-YUc9Isr8rOZEEAPCrL8HFKXW32QZZM64kPV+T83KeN77MrU+A+0LjndStTGPzZJJR0r8k9TGByMDtXb9yM+5nw==",
+      "version": "24.1.10",
+      "resolved": "https://registry.npmjs.org/streamr-network/-/streamr-network-24.1.10.tgz",
+      "integrity": "sha512-O8CHTa6bDEZRuBVqztzQZBc5wWto+f+MCK4sNb8YiAlffVuvyK5XeSGMzstDGYdvAmWEN5T4MbqX55EJ0qek8Q==",
       "requires": {
         "bufferutil": "^4.0.1",
         "cancelable-promise": "^3.2.3",
@@ -9491,6 +9433,7 @@
         "pino-pretty": "^4.7.1",
         "speedometer": "^1.1.0",
         "streamr-client-protocol": "^8.0.2",
+        "strict-event-emitter-types": "^2.0.0",
         "strip-ansi": "^6.0.0",
         "tmp": "^0.2.1",
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v18.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9463,9 +9463,9 @@
       }
     },
     "streamr-test-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/streamr-test-utils/-/streamr-test-utils-1.3.1.tgz",
-      "integrity": "sha512-3ol+bRQOSUz6Qjso0/VDBNzTxD9msizCOtsHgx7YqGYkxtIUSlGbsVtZh3JhBnnm53BNyaNHS74+N7Mjoa+w5Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/streamr-test-utils/-/streamr-test-utils-1.3.2.tgz",
+      "integrity": "sha512-qYFJ9ra0FtTq3grn9uXTIST/vU91bxAswOMQX275KNdD7+Lu8Z0YRPr51fOdV6iE+kdrXUsPWbKvOS/6iCNBFQ==",
       "dev": true
     },
     "strict-event-emitter-types": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "pump": "^3.0.0",
     "qs": "^6.10.1",
     "streamr-client": "^5.2.1",
-    "streamr-network": "^24.1.9",
+    "streamr-network": "^24.1.10",
     "ts-jest": "^26.5.4",
     "typescript": "^4.2.4",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v18.14.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "jest-circus": "^26.6.3",
     "sinon": "^10.0.0",
     "stream-to-array": "^2.3.0",
-    "streamr-test-utils": "^1.3.1",
+    "streamr-test-utils": "^1.3.2",
     "supertest": "^6.1.3"
   }
 }

--- a/test/integration/broker.test.ts
+++ b/test/integration/broker.test.ts
@@ -124,25 +124,23 @@ describe('broker: end-to-end', () => {
         const client2Messages: Todo[] = []
         const client3Messages: Todo[] = []
 
-        client1.subscribe({
-            stream: freshStreamId
-        }, (message, metadata) => {
-            client1Messages.push(message)
-        })
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, (message, metadata) => {
-            client2Messages.push(message)
-        })
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, (message, metadata) => {
-            client3Messages.push(message)
-        })
-
-        await wait(1000)
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, (message) => {
+                client1Messages.push(message)
+            }),
+            client2.subscribe({
+                stream: freshStreamId
+            }, (message) => {
+                client2Messages.push(message)
+            }),
+            client3.subscribe({
+                stream: freshStreamId
+            }, (message) => {
+                client3Messages.push(message)
+            })
+        ])
 
         await client1.publish(freshStreamId, {
             key: 1
@@ -274,23 +272,23 @@ describe('broker: end-to-end', () => {
         const client2Messages: Todo[] = []
         const client3Messages: Todo[] = []
 
-        client1.subscribe({
-            stream: freshStreamId
-        }, (message, metadata) => {
-            client1Messages.push(message)
-        })
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, (message, metadata) => {
-            client2Messages.push(message)
-        })
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, (message, metadata) => {
-            client3Messages.push(message)
-        })
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, (message) => {
+                client1Messages.push(message)
+            }),
+            client2.subscribe({
+                stream: freshStreamId
+            }, (message) => {
+                client2Messages.push(message)
+            }),
+            client3.subscribe({
+                stream: freshStreamId
+            }, (message) => {
+                client3Messages.push(message)
+            })
+        ])
 
         for (let i = 1; i <= 3; ++i) {
             // eslint-disable-next-line no-await-in-loop
@@ -347,17 +345,17 @@ describe('broker: end-to-end', () => {
     })
 
     it('happy-path: resend last request via websocket', async () => {
-        client1.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, () => {})
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client2.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client3.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+        ])
 
         await client1.publish(freshStreamId, {
             key: 1
@@ -378,32 +376,32 @@ describe('broker: end-to-end', () => {
         const client2Messages: Todo[] = []
         const client3Messages: Todo[] = []
 
-        client1.resend({
-            stream: freshStreamId,
-            resend: {
-                last: 2
-            }
-        }, (message) => {
-            client1Messages.push(message)
-        })
-
-        client2.resend({
-            stream: freshStreamId,
-            resend: {
-                last: 2
-            }
-        }, (message) => {
-            client2Messages.push(message)
-        })
-
-        client3.resend({
-            stream: freshStreamId,
-            resend: {
-                last: 2
-            }
-        }, (message) => {
-            client3Messages.push(message)
-        })
+        await Promise.all([
+                client1.resend({
+                stream: freshStreamId,
+                resend: {
+                    last: 2
+                }
+            }, (message) => {
+                client1Messages.push(message)
+            }),
+            client2.resend({
+                stream: freshStreamId,
+                resend: {
+                    last: 2
+                }
+            }, (message) => {
+                client2Messages.push(message)
+            }),
+            client3.resend({
+                stream: freshStreamId,
+                resend: {
+                    last: 2
+                }
+            }, (message) => {
+                client3Messages.push(message)
+            })
+        ])
 
         await waitForCondition(() => client2Messages.length === 2 && client3Messages.length === 2)
         await waitForCondition(() => client1Messages.length === 2)
@@ -437,17 +435,17 @@ describe('broker: end-to-end', () => {
     })
 
     it('happy-path: resend from request via websocket', async () => {
-        client1.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, () => {})
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client2.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client3.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+        ])
 
         await client1.publish(freshStreamId, {
             key: 1
@@ -472,39 +470,38 @@ describe('broker: end-to-end', () => {
         const client1Messages: Todo[] = []
         const client2Messages: Todo[] = []
         const client3Messages: Todo[] = []
-
-        client1.resend({
-            stream: freshStreamId,
-            resend: {
-                from: {
-                    timestamp: timeAfterFirstMessagePublished,
+        await Promise.all([
+            client1.resend({
+                stream: freshStreamId,
+                resend: {
+                    from: {
+                        timestamp: timeAfterFirstMessagePublished,
+                    }
                 }
-            }
-        }, (message) => {
-            client1Messages.push(message)
-        })
-
-        client2.resend({
-            stream: freshStreamId,
-            resend: {
-                from: {
-                    timestamp: timeAfterFirstMessagePublished,
+            }, (message) => {
+                client1Messages.push(message)
+            }),
+            client2.resend({
+                stream: freshStreamId,
+                resend: {
+                    from: {
+                        timestamp: timeAfterFirstMessagePublished,
+                    }
                 }
-            }
-        }, (message) => {
-            client2Messages.push(message)
-        })
-
-        client3.resend({
-            stream: freshStreamId,
-            resend: {
-                from: {
-                    timestamp: timeAfterFirstMessagePublished,
+            }, (message) => {
+                client2Messages.push(message)
+            }),
+            client3.resend({
+                stream: freshStreamId,
+                resend: {
+                    from: {
+                        timestamp: timeAfterFirstMessagePublished,
+                    }
                 }
-            }
-        }, (message) => {
-            client3Messages.push(message)
-        })
+            }, (message) => {
+                client3Messages.push(message)
+            })
+        ])
 
         await waitForCondition(() => client2Messages.length === 3 && client3Messages.length === 3)
         await waitForCondition(() => client1Messages.length === 3)
@@ -547,17 +544,17 @@ describe('broker: end-to-end', () => {
     })
 
     it('happy-path: resend range request via websocket', async () => {
-        client1.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, () => {})
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client2.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client3.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+        ])
 
         await client1.publish(freshStreamId, {
             key: 1
@@ -586,47 +583,49 @@ describe('broker: end-to-end', () => {
         const client2Messages: Todo[] = []
         const client3Messages: Todo[] = []
 
-        client1.resend({
-            stream: freshStreamId,
-            resend: {
-                from: {
-                    timestamp: timeAfterFirstMessagePublished,
-                },
-                to: {
-                    timestamp: timeAfterThirdMessagePublished,
+        await Promise.all([
+            client1.resend({
+                stream: freshStreamId,
+                resend: {
+                    from: {
+                        timestamp: timeAfterFirstMessagePublished,
+                    },
+                    to: {
+                        timestamp: timeAfterThirdMessagePublished,
+                    }
                 }
-            }
-        }, (message) => {
-            client1Messages.push(message)
-        })
+            }, (message) => {
+                client1Messages.push(message)
+            }),
 
-        client2.resend({
-            stream: freshStreamId,
-            resend: {
-                from: {
-                    timestamp: timeAfterFirstMessagePublished,
-                },
-                to: {
-                    timestamp: timeAfterThirdMessagePublished,
+            client2.resend({
+                stream: freshStreamId,
+                resend: {
+                    from: {
+                        timestamp: timeAfterFirstMessagePublished,
+                    },
+                    to: {
+                        timestamp: timeAfterThirdMessagePublished,
+                    }
                 }
-            }
-        }, (message) => {
-            client2Messages.push(message)
-        })
+            }, (message) => {
+                client2Messages.push(message)
+            }),
 
-        client3.resend({
-            stream: freshStreamId,
-            resend: {
-                from: {
-                    timestamp: timeAfterFirstMessagePublished,
-                },
-                to: {
-                    timestamp: timeAfterThirdMessagePublished,
+            client3.resend({
+                stream: freshStreamId,
+                resend: {
+                    from: {
+                        timestamp: timeAfterFirstMessagePublished,
+                    },
+                    to: {
+                        timestamp: timeAfterThirdMessagePublished,
+                    }
                 }
-            }
-        }, (message) => {
-            client3Messages.push(message)
-        })
+            }, (message) => {
+                client3Messages.push(message)
+            })
+        ])
 
         await waitForCondition(() => client2Messages.length === 2 && client3Messages.length === 2)
         await waitForCondition(() => client1Messages.length === 2)
@@ -660,17 +659,17 @@ describe('broker: end-to-end', () => {
     })
 
     it('happy-path: resend last request via http', async () => {
-        client1.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, () => {})
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client2.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client3.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+        ])
 
         await client1.publish(freshStreamId, {
             key: 1
@@ -772,17 +771,17 @@ describe('broker: end-to-end', () => {
     })
 
     it('happy-path: resend from request via http', async () => {
-        client1.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, () => {})
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client2.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client3.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+        ])
 
         await client1.publish(freshStreamId, {
             key: 1
@@ -856,17 +855,17 @@ describe('broker: end-to-end', () => {
     })
 
     it('happy-path: resend range request via http', async () => {
-        client1.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client2.subscribe({
-            stream: freshStreamId
-        }, () => {})
-
-        client3.subscribe({
-            stream: freshStreamId
-        }, () => {})
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client2.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+            client3.subscribe({
+                stream: freshStreamId
+            }, () => {}),
+        ])
 
         await client1.publish(freshStreamId, {
             key: 1

--- a/test/integration/mqtt.test.ts
+++ b/test/integration/mqtt.test.ts
@@ -69,7 +69,9 @@ describe('mqtt: end-to-end', () => {
             wsPort: wsPort3,
             mqttPort: mqttPort3
         })
+    }, 15000)
 
+    beforeEach(async () => {
         client1 = createClient(wsPort1, privateKey)
         client2 = createClient(wsPort2, privateKey)
         client3 = createClient(wsPort3, privateKey)
@@ -86,17 +88,23 @@ describe('mqtt: end-to-end', () => {
     afterEach(async () => {
         await tracker.stop()
 
-        await client1.ensureDisconnected()
-        await client2.ensureDisconnected()
-        await client3.ensureDisconnected()
+        await Promise.all([
+            client1.ensureDisconnected(),
+            client2.ensureDisconnected(),
+            client3.ensureDisconnected(),
+        ])
 
-        await mqttClient1.end(true)
-        await mqttClient2.end(true)
-        await mqttClient3.end(true)
+        await Promise.all([
+            mqttClient1.end(true),
+            mqttClient2.end(true),
+            mqttClient3.end(true),
+        ])
 
-        await broker1.close()
-        await broker2.close()
-        await broker3.close()
+        await Promise.all([
+            broker1.close(),
+            broker2.close(),
+            broker3.close(),
+        ])
     }, 15000)
 
     it('happy-path: real-time mqtt plain text producing and consuming', async () => {
@@ -112,15 +120,15 @@ describe('mqtt: end-to-end', () => {
         await mqttClient2.subscribe(freshStream1.id)
         await mqttClient3.subscribe(freshStream1.id)
 
-        mqttClient1.on('message', (topic, message) => {
+        mqttClient1.on('message', (_topic, message) => {
             client1Messages.push(JSON.parse(message.toString()))
         })
 
-        mqttClient2.on('message', (topic, message) => {
+        mqttClient2.on('message', (_topic, message) => {
             client2Messages.push(JSON.parse(message.toString()))
         })
 
-        mqttClient3.on('message', (topic, message) => {
+        mqttClient3.on('message', (_topic, message) => {
             client3Messages.push(JSON.parse(message.toString()))
         })
 
@@ -132,7 +140,7 @@ describe('mqtt: end-to-end', () => {
         await waitForCondition(() => client2Messages.length === 1)
         await waitForCondition(() => client3Messages.length === 1)
 
-        mqttClient2.publish(freshStream1.id, 'key: 2', {
+        await mqttClient2.publish(freshStream1.id, 'key: 2', {
             qos: 1
         })
 
@@ -140,7 +148,7 @@ describe('mqtt: end-to-end', () => {
         await waitForCondition(() => client2Messages.length === 2)
         await waitForCondition(() => client3Messages.length === 2)
 
-        mqttClient3.publish(freshStream1.id, 'key: 3', {
+        await mqttClient3.publish(freshStream1.id, 'key: 3', {
             qos: 0
         })
 
@@ -195,11 +203,11 @@ describe('mqtt: end-to-end', () => {
         await mqttClient1.subscribe(freshStream1.id)
         await mqttClient2.subscribe(freshStream1.id)
 
-        mqttClient1.on('message', (topic, message) => {
+        mqttClient1.on('message', (_topic, message) => {
             client1Messages.push(JSON.parse(message.toString()))
         })
 
-        mqttClient2.on('message', (topic, message) => {
+        mqttClient2.on('message', (_topic, message) => {
             client2Messages.push(JSON.parse(message.toString()))
         })
 
@@ -212,7 +220,7 @@ describe('mqtt: end-to-end', () => {
         await waitForCondition(() => client1Messages.length === 1)
         await waitForCondition(() => client2Messages.length === 1)
 
-        mqttClient2.publish(freshStream1.id, JSON.stringify({
+        await mqttClient2.publish(freshStream1.id, JSON.stringify({
             key: 2
         }), {
             qos: 1
@@ -249,29 +257,28 @@ describe('mqtt: end-to-end', () => {
         await waitForCondition(() => mqttClient1.connected)
 
         await mqttClient1.subscribe(freshStream1.id)
-        mqttClient1.on('message', (topic, message) => {
+        mqttClient1.on('message', (_topic, message) => {
             client4Messages.push(JSON.parse(message.toString()))
         })
 
-        client1.subscribe({
-            stream: freshStream1.id
-        }, (message, metadata) => {
-            client1Messages.push(message)
-        })
+        await Promise.all([
+            client1.subscribe({
+                stream: freshStream1.id
+            }, (message) => {
+                client1Messages.push(message)
+            }),
+            client2.subscribe({
+                stream: freshStream1.id
+            }, (message) => {
+                client2Messages.push(message)
+            }),
+            client3.subscribe({
+                stream: freshStream1.id
+            }, (message) => {
+                client3Messages.push(message)
+            })
+        ])
 
-        client2.subscribe({
-            stream: freshStream1.id
-        }, (message, metadata) => {
-            client2Messages.push(message)
-        })
-
-        client3.subscribe({
-            stream: freshStream1.id
-        }, (message, metadata) => {
-            client3Messages.push(message)
-        })
-
-        await wait(2000) // TODO: seems like this is needed for subscribes to go thru?
         await client1.publish(freshStream1.id, {
             key: 1
         })
@@ -283,7 +290,7 @@ describe('mqtt: end-to-end', () => {
         })
 
         await wait(100)
-        mqttClient1.publish(freshStream1.id, JSON.stringify({
+        await mqttClient1.publish(freshStream1.id, JSON.stringify({
             key: 4
         }), {
             qos: 1


### PR DESCRIPTION
Updates `streamr-network` to `24.1.0`. This includes fixes intended to resolve the ongoing resend issues we've been experiencing.

Also updates `streamr-test-utils` to `1.3.2` to get better stack traces for `waitForEvent` and `waitForCondition`. See https://github.com/streamr-dev/streamr-test-utils/pull/9

After updating I noticed more flakey tests. Ensuring all tests `await` every `client.subscribe` seems to fix it. This is how they should be set up anyway, likely leftover from working with the `4.x` `streamr-client` where `subscribe` was sync.
