### PR TITLE
Refactor websocket resend handler

### DIFF
--- a/src/websocket/RequestHandler.ts
+++ b/src/websocket/RequestHandler.ts
@@ -168,12 +168,10 @@ export class RequestHandler {
         request: ResendFromRequest|ResendLastRequest|ResendRangeRequest,
         streamingStorageData: NodeJS.ReadableStream
     ) {
-        let nothingToResend = true
         let sentMessages = 0
     
         const msgHandler = (unicastMessage: UnicastMessage) => {
-            if (nothingToResend) {
-                nothingToResend = false
+            if (sentMessages === 0) {
                 connection.send(new ControlLayer.ResendResponseResending(request))
             }
     
@@ -190,7 +188,7 @@ export class RequestHandler {
     
         const doneHandler = () => {
             logger.info('Finished resend %s for stream %s with a total of %d sent messages', request.requestId, request.streamId, sentMessages)
-            if (nothingToResend) {
+            if (sentMessages === 0) {
                 connection.send(new ControlLayer.ResendResponseNoResend({
                     version: request.version,
                     requestId: request.requestId,

--- a/src/websocket/RequestHandler.ts
+++ b/src/websocket/RequestHandler.ts
@@ -159,7 +159,7 @@ export class RequestHandler {
                     r.msgChainId,
                 )
             default: 
-                throw new Error('Assertion failed')
+                throw new Error('Assertion failed: request.type=' + request.type)
         }
     }
 

--- a/src/websocket/RequestHandler.ts
+++ b/src/websocket/RequestHandler.ts
@@ -13,9 +13,8 @@ import { Connection } from './Connection'
 import { MAX_SEQUENCE_NUMBER_VALUE, MIN_SEQUENCE_NUMBER_VALUE } from '../http/DataQueryEndpoints'
 import { StreamFetcher } from '../StreamFetcher'
 
-const logger = getLogger('streamr:RequestHandlers')
+const logger = getLogger('streamr:RequestHandler')
 
-type ControlMessage = Protocol.ControlLayer.ControlMessage
 type SubscribeRequest = Protocol.ControlLayer.SubscribeRequest
 type UnsubscribeRequest = Protocol.ControlLayer.UnsubscribeRequest
 type ResendLastRequest = Protocol.ControlLayer.ResendLastRequest
@@ -24,9 +23,7 @@ type ResendRangeRequest = Protocol.ControlLayer.ResendRangeRequest
 type PublishRequest = Protocol.ControlLayer.PublishRequest
 type UnicastMessage = Protocol.ControlLayer.UnicastMessage
 
-type RequestHandler = (connection: Connection, request: ControlMessage) => void
-
-export class RequestHandlers {
+export class RequestHandler {
 
     networkNode: NetworkNode
     streamFetcher: StreamFetcher
@@ -34,37 +31,48 @@ export class RequestHandlers {
     streams: StreamStateManager
     subscriptionManager: SubscriptionManager
     metrics: Metrics
-    requestHandlersByMessageType: Todo
 
     constructor(   
         networkNode: NetworkNode,
         streamFetcher: StreamFetcher,
         publisher: Publisher,
+        streams: StreamStateManager,
         subscriptionManager: SubscriptionManager,
-        metrics: Metrics
+        metrics: Metrics,
     ) {
         this.networkNode = networkNode
         this.streamFetcher = streamFetcher
         this.publisher = publisher
+        this.streams = streams
         this.subscriptionManager = subscriptionManager
         this.metrics = metrics
-        this.requestHandlersByMessageType = {
-            [ControlLayer.ControlMessage.TYPES.SubscribeRequest]: this.handleSubscribeRequest,
-            [ControlLayer.ControlMessage.TYPES.UnsubscribeRequest]: this.handleUnsubscribeRequest,
-            [ControlLayer.ControlMessage.TYPES.ResendLastRequest]: this.handleResendLastRequest,
-            [ControlLayer.ControlMessage.TYPES.ResendFromRequest]: this.handleResendFromRequest,
-            [ControlLayer.ControlMessage.TYPES.ResendRangeRequest]: this.handleResendRangeRequest,
-            [ControlLayer.ControlMessage.TYPES.PublishRequest]: this.handlePublishRequest,
+    }
+
+    handleRequest(connection: Connection, request: Todo): Promise<any> {
+        switch (request.type) {
+            case ControlLayer.ControlMessage.TYPES.SubscribeRequest: 
+                return this.subscribe(connection, request)
+            case ControlLayer.ControlMessage.TYPES.UnsubscribeRequest: 
+                return this.unsubscribe(connection, request)
+            case ControlLayer.ControlMessage.TYPES.PublishRequest: 
+                return this.publish(connection, request)
+            case ControlLayer.ControlMessage.TYPES.ResendLastRequest: 
+            case ControlLayer.ControlMessage.TYPES.ResendFromRequest: 
+            case ControlLayer.ControlMessage.TYPES.ResendRangeRequest: 
+                return this.resend(connection, request)
+            default:
+                connection.send(new ControlLayer.ErrorResponse({
+                    version: request.version,
+                    requestId: request.requestId,
+                    errorMessage: `Unknown request type: ${request.type}`,
+                    // @ts-expect-error
+                    errorCode: 'INVALID_REQUEST',
+                }))
+                return Promise.resolve()
         }
-        this.streams = new StreamStateManager()
-        this.networkNode.addMessageListener(this._broadcastMessage.bind(this))
     }
 
-    getInstance(messageType: Todo): RequestHandler|undefined {
-        return this.requestHandlersByMessageType[messageType]
-    }
-
-    async handlePublishRequest(connection: Connection, request: PublishRequest) {
+    private async publish(connection: Connection, request: PublishRequest) {
         const { streamMessage } = request
 
         try {
@@ -106,17 +114,69 @@ export class RequestHandlers {
         }
     }
 
-    // TODO: Extract resend stuff to class?
-    async handleResendRequest(connection: Connection, request: ResendFromRequest|ResendLastRequest|ResendRangeRequest, resendTypeHandler: () => NodeJS.ReadableStream) {
+    private async resend(connection: Connection, request: ResendFromRequest|ResendLastRequest|ResendRangeRequest) {
+        await this._validateSubscribeOrResendRequest(request)
+        const streamingStorageData = this.getStreamStorageData(request)
+        return this.sendResendResponse(connection, request, streamingStorageData)
+    }
+
+    private getStreamStorageData(request: ResendFromRequest|ResendLastRequest|ResendRangeRequest) {
+        let r
+        switch (request.type) {
+            case ControlLayer.ControlMessage.TYPES.ResendLastRequest: 
+                r = request as ResendLastRequest
+                return this.networkNode.requestResendLast(
+                    r.streamId,
+                    r.streamPartition,
+                    uuidv4(),
+                    r.numberLast,
+                )
+            case ControlLayer.ControlMessage.TYPES.ResendFromRequest: 
+                r = request as ResendFromRequest
+                this.networkNode.requestResendFrom(
+                    r.streamId,
+                    r.streamPartition,
+                    uuidv4(),
+                    r.fromMsgRef.timestamp,
+                    // TODO client should provide sequenceNumber, remove MIN_SEQUENCE_NUMBER_VALUE defaults when NET-267 have been implemented
+                    r.fromMsgRef.sequenceNumber || MIN_SEQUENCE_NUMBER_VALUE,
+                    r.publisherId,
+                    // @ts-expect-error
+                    r.msgChainId,
+                )
+            case ControlLayer.ControlMessage.TYPES.ResendRangeRequest: 
+                r = request as ResendRangeRequest
+                this.networkNode.requestResendRange(
+                    r.streamId,
+                    r.streamPartition,
+                    uuidv4(),
+                    r.fromMsgRef.timestamp,
+                    // TODO client should provide sequenceNumber, remove MIN_SEQUENCE_NUMBER_VALUE&MAX_SEQUENCE_NUMBER_VALUE defaults when NET-267 have been implemented
+                    r.fromMsgRef.sequenceNumber || MIN_SEQUENCE_NUMBER_VALUE,  
+                    r.toMsgRef.timestamp,
+                    r.toMsgRef.sequenceNumber || MAX_SEQUENCE_NUMBER_VALUE,
+                    r.publisherId,
+                    r.msgChainId,
+                )
+            default: 
+                throw new Error('Assertion failed')
+        }
+    }
+
+    private async sendResendResponse(
+        connection: Connection, 
+        request: ResendFromRequest|ResendLastRequest|ResendRangeRequest,
+        streamingStorageData: NodeJS.ReadableStream
+    ) {
         let nothingToResend = true
         let sentMessages = 0
-
+    
         const msgHandler = (unicastMessage: UnicastMessage) => {
             if (nothingToResend) {
                 nothingToResend = false
                 connection.send(new ControlLayer.ResendResponseResending(request))
             }
-
+    
             const { streamMessage } = unicastMessage
             this.metrics.record('outBytes', streamMessage.getSerializedContent().length)
             this.metrics.record('outMessages', 1)
@@ -127,7 +187,7 @@ export class RequestHandlers {
                 streamMessage,
             }))
         }
-
+    
         const doneHandler = () => {
             logger.info('Finished resend %s for stream %s with a total of %d sent messages', request.requestId, request.streamId, sentMessages)
             if (nothingToResend) {
@@ -146,13 +206,11 @@ export class RequestHandlers {
                 }))
             }
         }
-
+    
         try {
-            await this._validateSubscribeOrResendRequest(request)
             if (connection.isDead()) {
                 return
             }
-            const streamingStorageData = resendTypeHandler()
             const pauseHandler = () => streamingStorageData.pause()
             const resumeHandler = () => streamingStorageData.resume()
             connection.addOngoingResend(streamingStorageData)
@@ -175,65 +233,7 @@ export class RequestHandlers {
         }
     }
 
-    async handleResendLastRequest(connection: Connection, request: ResendLastRequest) {
-        await this.handleResendRequest(connection, request, () => this.networkNode.requestResendLast(
-            request.streamId,
-            request.streamPartition,
-            uuidv4(),
-            request.numberLast,
-        ))
-    }
-
-    async handleResendFromRequest(connection: Connection, request: ResendFromRequest) {
-        await this.handleResendRequest(connection, request, () => this.networkNode.requestResendFrom(
-            request.streamId,
-            request.streamPartition,
-            uuidv4(),
-            request.fromMsgRef.timestamp,
-            // TODO client should provide sequenceNumber, remove MIN_SEQUENCE_NUMBER_VALUE defaults when NET-267 have been implemented
-            request.fromMsgRef.sequenceNumber || MIN_SEQUENCE_NUMBER_VALUE,
-            request.publisherId,
-            // @ts-expect-error
-            request.msgChainId,
-        ))
-    }
-
-    async handleResendRangeRequest(connection: Connection, request: ResendRangeRequest) {
-        await this.handleResendRequest(connection, request, () => this.networkNode.requestResendRange(
-            request.streamId,
-            request.streamPartition,
-            uuidv4(),
-            request.fromMsgRef.timestamp,
-            // TODO client should provide sequenceNumber, remove MIN_SEQUENCE_NUMBER_VALUE&MAX_SEQUENCE_NUMBER_VALUE defaults when NET-267 have been implemented
-            request.fromMsgRef.sequenceNumber || MIN_SEQUENCE_NUMBER_VALUE,  
-            request.toMsgRef.timestamp,
-            request.toMsgRef.sequenceNumber || MAX_SEQUENCE_NUMBER_VALUE,
-            request.publisherId,
-            request.msgChainId,
-        ))
-    }
-
-    _broadcastMessage(streamMessage: Protocol.StreamMessage) {
-        const streamId = streamMessage.getStreamId()
-        const streamPartition = streamMessage.getStreamPartition()
-        const stream = this.streams.get(streamId, streamPartition)
-
-        if (stream) {
-            stream.forEachConnection((connection: Connection) => {
-                connection.send(new ControlLayer.BroadcastMessage({
-                    requestId: '', // TODO: can we have here the requestId of the original SubscribeRequest?
-                    streamMessage,
-                }))
-            })
-
-            this.metrics.record('outBytes', streamMessage.getSerializedContent().length * stream.getConnections().length)
-            this.metrics.record('outMessages', stream.getConnections().length)
-        } else {
-            logger.debug('broadcastMessage: stream "%s:%d" not found', streamId, streamPartition)
-        }
-    }
-
-    async handleSubscribeRequest(connection: Connection, request: SubscribeRequest) {
+    private async subscribe(connection: Connection, request: SubscribeRequest) {
         try {
             await this._validateSubscribeOrResendRequest(request)
 
@@ -293,7 +293,7 @@ export class RequestHandlers {
         }
     }
 
-    handleUnsubscribeRequest(connection: Connection, request: UnsubscribeRequest, noAck = false) {
+    async unsubscribe(connection: Connection, request: UnsubscribeRequest, noAck = false) {
         const stream = this.streams.get(request.streamId, request.streamPartition)
 
         if (stream) {
@@ -347,7 +347,7 @@ export class RequestHandlers {
         }
     }
 
-    async _validateSubscribeOrResendRequest(request: SubscribeRequest|ResendFromRequest|ResendLastRequest|ResendRangeRequest) {
+    private async _validateSubscribeOrResendRequest(request: SubscribeRequest|ResendFromRequest|ResendLastRequest|ResendRangeRequest) {
         if (Utils.StreamMessageValidator.isKeyExchangeStream(request.streamId)) {
             if (request.streamPartition !== 0) {
                 throw new Error(`Key exchange streams only have partition 0. Tried to subscribe to ${request.streamId}:${request.streamPartition}`)

--- a/src/websocket/RequestHandler.ts
+++ b/src/websocket/RequestHandler.ts
@@ -133,7 +133,7 @@ export class RequestHandler {
                 )
             case ControlLayer.ControlMessage.TYPES.ResendFromRequest: 
                 r = request as ResendFromRequest
-                this.networkNode.requestResendFrom(
+                return this.networkNode.requestResendFrom(
                     r.streamId,
                     r.streamPartition,
                     uuidv4(),
@@ -146,7 +146,7 @@ export class RequestHandler {
                 )
             case ControlLayer.ControlMessage.TYPES.ResendRangeRequest: 
                 r = request as ResendRangeRequest
-                this.networkNode.requestResendRange(
+                return this.networkNode.requestResendRange(
                     r.streamId,
                     r.streamPartition,
                     uuidv4(),

--- a/src/websocket/WebsocketServer.ts
+++ b/src/websocket/WebsocketServer.ts
@@ -197,6 +197,9 @@ export class WebsocketServer extends EventEmitter {
                             logger.debug('socket "%s" sent request "%s" with contents "%o"', connection.id, request.type, request)
                             await this.requestHandler.handleRequest(connection, request)
                         } catch (err) {
+                            if (connection.isDead()) {
+                                return
+                            }
                             connection.send(new ControlLayer.ErrorResponse({
                                 version: request.version,
                                 requestId: request.requestId,

--- a/src/websocket/WebsocketServer.ts
+++ b/src/websocket/WebsocketServer.ts
@@ -175,7 +175,7 @@ export class WebsocketServer extends EventEmitter {
 
                     const msg = copy(message)
 
-                    setImmediate(() => {
+                    setImmediate(async () => {
                         if (connection.isDead()) {
                             return
                         }
@@ -195,8 +195,7 @@ export class WebsocketServer extends EventEmitter {
 
                         try {
                             logger.debug('socket "%s" sent request "%s" with contents "%o"', connection.id, request.type, request)
-                            // TODO we should await this handling so that the catch block will catch any errors?
-                            this.requestHandler.handleRequest(connection, request)
+                            await this.requestHandler.handleRequest(connection, request)
                         } catch (err) {
                             connection.send(new ControlLayer.ErrorResponse({
                                 version: request.version,

--- a/src/websocket/WebsocketServer.ts
+++ b/src/websocket/WebsocketServer.ts
@@ -7,12 +7,13 @@ const { ControlLayer, MessageLayer, Errors } = Protocol
 // @ts-expect-error no type definitions
 import ab2str from 'arraybuffer-to-string'
 import uWS, { TemplatedApp } from 'uWebSockets.js'
-import { RequestHandlers } from './RequestHandlers'
+import { RequestHandler } from './RequestHandler'
 import { Connection } from './Connection'
 import { Metrics } from 'streamr-network/dist/helpers/MetricsContext'
 import { Publisher } from '../Publisher'
 import { SubscriptionManager } from '../SubscriptionManager'
 import { getLogger } from '../helpers/logger'
+import { StreamStateManager } from '../StreamStateManager'
 
 const logger = getLogger('streamr:WebsocketServer')
 
@@ -20,7 +21,7 @@ export class WebsocketServer extends EventEmitter {
 
     wss: TemplatedApp
     _listenSocket: Todo
-    requestHandlers: RequestHandlers
+    requestHandler: RequestHandler
     connections: Map<string,Connection>
     pingInterval: number
     metrics: Metrics
@@ -81,7 +82,9 @@ export class WebsocketServer extends EventEmitter {
                 }
             })
 
-        this.requestHandlers = new RequestHandlers(networkNode, streamFetcher, publisher, subscriptionManager, this.metrics)
+        const streams = new StreamStateManager()
+        this.requestHandler = new RequestHandler(networkNode, streamFetcher, publisher, streams, subscriptionManager, this.metrics)
+        networkNode.addMessageListener((msg: Protocol.MessageLayer.StreamMessage) => this._broadcastMessage(msg, streams))
 
         this._pingInterval = setInterval(() => {
             this._pingConnections()
@@ -191,19 +194,9 @@ export class WebsocketServer extends EventEmitter {
                         }
 
                         try {
-                            const handler = this.requestHandlers.getInstance(request.type)
-                            if (handler) {
-                                logger.debug('socket "%s" sent request "%s" with contents "%o"', connection.id, request.type, request)
-                                handler.call(this.requestHandlers, connection, request)
-                            } else {
-                                connection.send(new ControlLayer.ErrorResponse({
-                                    version: request.version,
-                                    requestId: request.requestId,
-                                    errorMessage: `Unknown request type: ${request.type}`,
-                                    // @ts-expect-error
-                                    errorCode: 'INVALID_REQUEST',
-                                }))
-                            }
+                            logger.debug('socket "%s" sent request "%s" with contents "%o"', connection.id, request.type, request)
+                            // TODO we should await this handling so that the catch block will catch any errors?
+                            this.requestHandler.handleRequest(connection, request)
                         } catch (err) {
                             connection.send(new ControlLayer.ErrorResponse({
                                 version: request.version,
@@ -266,7 +259,7 @@ export class WebsocketServer extends EventEmitter {
         // Unsubscribe from all streams
         connection.forEachStream((stream: Todo) => {
             // for cleanup, spoof an UnsubscribeRequest to ourselves on the removed connection
-            this.requestHandlers.handleUnsubscribeRequest(
+            this.requestHandler.unsubscribe(
                 connection,
                 new ControlLayer.UnsubscribeRequest({
                     requestId: uuidv4(),
@@ -288,7 +281,7 @@ export class WebsocketServer extends EventEmitter {
     close() {
         clearInterval(this._pingInterval)
 
-        this.requestHandlers.close()
+        this.requestHandler.close()
 
         return new Promise((resolve, reject) => {
             try {
@@ -327,5 +320,25 @@ export class WebsocketServer extends EventEmitter {
                 connection.emit('forceClose')
             }
         })
+    }
+
+    private _broadcastMessage(streamMessage: Protocol.StreamMessage, streams: StreamStateManager) {
+        const streamId = streamMessage.getStreamId()
+        const streamPartition = streamMessage.getStreamPartition()
+        const stream = streams.get(streamId, streamPartition)
+
+        if (stream) {
+            stream.forEachConnection((connection: Connection) => {
+                connection.send(new ControlLayer.BroadcastMessage({
+                    requestId: '', // TODO: can we have here the requestId of the original SubscribeRequest?
+                    streamMessage,
+                }))
+            })
+
+            this.metrics.record('outBytes', streamMessage.getSerializedContent().length * stream.getConnections().length)
+            this.metrics.record('outMessages', stream.getConnections().length)
+        } else {
+            logger.debug('broadcastMessage: stream "%s:%d" not found', streamId, streamPartition)
+        }
     }
 }


### PR DESCRIPTION
Add TypeScript annotations for `RequestHandler` and small refactoring to the structure.

Also a bug fix to error handling: `this.requestHandler.handleRequest` now awaits the response so that the catch block can catch any errors.