### PR TITLE
NET-283: Raw format for DataQueryEndpoints

### DIFF
--- a/src/http/DataQueryEndpoints.ts
+++ b/src/http/DataQueryEndpoints.ts
@@ -60,6 +60,24 @@ function parseIntIfExists(x: Todo) {
     return x === undefined ? undefined : parseInt(x)
 }
 
+const createEndpoint = (path: string, router: express.Router, callback: (req: Request, res: Response, streamId: string, partition: number, format: Format, version: number|undefined) => void) => {
+    router.get(path, (req: Request, res: Response) => {
+        const format = getFormat(req.query.format as string)
+        if (format === undefined) {
+            const errMsg = `Query parameter "format" is invalid: ${req.query.format}`
+            logger.error(errMsg)
+            res.status(400).send({
+                error: errMsg
+            })
+        } else {
+            const streamId = req.params.id
+            const partition = parseInt(req.params.partition)
+            const version = parseIntIfExists(req.query.version)
+            callback(req, res, streamId, partition, format, version)
+        }
+    })
+}
+
 export const router = (storage: Storage, streamFetcher: Todo, metricsContext: MetricsContext) => {
     const router = express.Router()
     const metrics = metricsContext.create('broker/http')
@@ -87,10 +105,8 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
         authenticator(streamFetcher, 'stream_subscribe'),
     )
 
-    router.get('/streams/:id/data/partitions/:partition/last', (req: Request, res: Response) => {
-        const partition = parseInt(req.params.partition)
+    createEndpoint('/streams/:id/data/partitions/:partition/last', router, (req: Request, res: Response, streamId: string, partition: number, format: Format, version: number|undefined) => {
         const count = req.query.count === undefined ? 1 : parseInt(req.query.count as string)
-        const version = parseIntIfExists(req.query.version)
         metrics.record('lastRequests', 1)
 
         if (Number.isNaN(count)) {
@@ -102,21 +118,19 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
             })
         } else {
             const streamingData = storage.requestLast(
-                req.params.id,
+                streamId,
                 partition,
                 count,
             )
 
-            streamData(res, streamingData, getFormat(req.query.format as string), version, metrics)
+            streamData(res, streamingData, format, version, metrics)
         }
     })
 
-    router.get('/streams/:id/data/partitions/:partition/from', (req: Request, res: Response) => {
-        const partition = parseInt(req.params.partition)
+    createEndpoint('/streams/:id/data/partitions/:partition/from', router, (req: Request, res: Response, streamId: string, partition: number, format: Format, version: number|undefined) => {
         const fromTimestamp = parseIntIfExists(req.query.fromTimestamp)
         const fromSequenceNumber = parseIntIfExists(req.query.fromSequenceNumber) || MIN_SEQUENCE_NUMBER_VALUE
         const { publisherId } = req.query
-        const version = parseIntIfExists(req.query.version)
         metrics.record('fromRequests', 1)
 
         if (fromTimestamp === undefined) {
@@ -135,7 +149,7 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
             })
         } else {
             const streamingData = storage.requestFrom(
-                req.params.id,
+                streamId,
                 partition,
                 fromTimestamp,
                 fromSequenceNumber,
@@ -143,13 +157,11 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
                 null,
             )
 
-            streamData(res, streamingData, getFormat(req.query.format as string), version, metrics)
+            streamData(res, streamingData, format, version, metrics)
         }
     })
 
-    router.get('/streams/:id/data/partitions/:partition/range', (req: Request, res: Response) => {
-        const partition = parseInt(req.params.partition)
-        const version = parseIntIfExists(req.query.version)
+    createEndpoint('/streams/:id/data/partitions/:partition/range', router, (req: Request, res: Response, streamId: string, partition: number, format: Format, version: number|undefined) => {
         const fromTimestamp = parseIntIfExists(req.query.fromTimestamp)
         const toTimestamp = parseIntIfExists(req.query.toTimestamp)
         const fromSequenceNumber = parseIntIfExists(req.query.fromSequenceNumber) || MIN_SEQUENCE_NUMBER_VALUE
@@ -196,7 +208,7 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
             })
         } else {
             const streamingData = storage.requestRange(
-                req.params.id,
+                streamId,
                 partition,
                 fromTimestamp,
                 fromSequenceNumber,
@@ -207,7 +219,7 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
                 null,
             )
 
-            streamData(res, streamingData, getFormat(req.query.format as string), version, metrics)
+            streamData(res, streamingData, format, version, metrics)
         }
     })
 

--- a/src/http/DataQueryFormat.ts
+++ b/src/http/DataQueryFormat.ts
@@ -1,0 +1,50 @@
+import { Protocol } from 'streamr-network'
+
+export interface Format {
+    getMessageAsString: (streamMessage: Protocol.StreamMessage, version: number|undefined) => string
+    contentType: string
+    delimiter: string
+    header: string
+    footer: string
+}
+
+const createJsonFormat = (getMessageAsString: (streamMessage: Protocol.StreamMessage, version: number|undefined) => string): Format => {
+    return {
+        getMessageAsString,
+        contentType: 'application/json',
+        delimiter: ',',
+        header: '[',
+        footer: ']'
+    }
+}
+
+const createPlainTextFormat = (getMessageAsString: (streamMessage: Protocol.StreamMessage, version: number|undefined) => string): Format => {
+    return {
+        getMessageAsString,
+        contentType: 'text/plain',
+        delimiter: '\n',
+        header: '',
+        footer: ''
+    }
+}
+
+const FORMATS: Record<string,Format> = {
+    // TODO could we deprecate protocol format?
+    'protocol': createJsonFormat((streamMessage: Protocol.StreamMessage, version: number|undefined) => JSON.stringify(streamMessage.serialize(version))),
+    'object': createJsonFormat((streamMessage: Protocol.StreamMessage) => JSON.stringify(streamMessage.toObject())),
+    // the raw format message is the same string which we have we have stored to Cassandra (if the version numbers match)
+    // -> TODO we could optimize the reading if we'd fetch the data from Cassandra as plain text
+    // currently we:
+    // 1) deserialize the string to an object in Storage._parseRow
+    // 2) serialize the same object to string here
+    'raw': createPlainTextFormat((streamMessage: Protocol.StreamMessage, version: number|undefined) => streamMessage.serialize(version))
+}
+
+export const getFormat = (id: string|undefined) => {
+    const key = id ?? 'object'
+    const result = FORMATS[key]
+    if (result === undefined) {
+        throw new Error(`Unknown format: ${id}`)
+    }
+    return result
+}

--- a/src/http/DataQueryFormat.ts
+++ b/src/http/DataQueryFormat.ts
@@ -40,7 +40,7 @@ const FORMATS: Record<string,Format> = {
     'raw': createPlainTextFormat((streamMessage: Protocol.StreamMessage, version: number|undefined) => streamMessage.serialize(version))
 }
 
-export const getFormat = (id: string|undefined) => {
+export const getFormat = (id: string|undefined): Format => {
     const key = id ?? 'object'
     const result = FORMATS[key]
     if (result === undefined) {

--- a/src/http/DataQueryFormat.ts
+++ b/src/http/DataQueryFormat.ts
@@ -40,11 +40,7 @@ const FORMATS: Record<string,Format> = {
     'raw': createPlainTextFormat((streamMessage: Protocol.StreamMessage, version: number|undefined) => streamMessage.serialize(version))
 }
 
-export const getFormat = (id: string|undefined): Format => {
+export const getFormat = (id: string|undefined): Format|undefined => {
     const key = id ?? 'object'
-    const result = FORMATS[key]
-    if (result === undefined) {
-        throw new Error(`Unknown format: ${id}`)
-    }
-    return result
+    return FORMATS[key]
 }

--- a/test/unit/http/DataQueryEndpoints.test.ts
+++ b/test/unit/http/DataQueryEndpoints.test.ts
@@ -93,6 +93,14 @@ describe('DataQueryEndpoints', () => {
                         error: 'Query parameter "count" not a number: sixsixsix',
                     }, done)
             })
+
+            it('responds 400 and error message if format parameter is invalid', (done) => {
+                testGetRequest('/api/v1/streams/streamId/data/partitions/0/last?format=foobar')
+                    .expect('Content-Type', /json/)
+                    .expect(400, {
+                        error: 'Query parameter "format" is invalid: foobar',
+                    }, done)
+            })
         })
 
         describe('GET /api/v1/streams/streamId/data/partitions/0/last', () => {

--- a/test/unit/http/DataQueryEndpoints.test.ts
+++ b/test/unit/http/DataQueryEndpoints.test.ts
@@ -118,6 +118,12 @@ describe('DataQueryEndpoints', () => {
                     .expect(streamMessages.map((msg) => msg.serialize(30)), done)
             })
 
+            it('responds with raw format', (done) => {
+                testGetRequest('/api/v1/streams/streamId/data/partitions/0/last?count=2&format=raw&version=30')
+                    .expect('Content-Type', 'text/plain')
+                    .expect(streamMessages.map((msg) => msg.serialize(30)).join('\n'), done)
+            })
+
             it('invokes networkNode#requestResendLast once with correct arguments', (done) => {
                 testGetRequest('/api/v1/streams/streamId/data/partitions/0/last')
                     .then(() => {


### PR DESCRIPTION
New format, which is easy and efficient to parse:
- messages are serialized, but not escaped with `JSON.stringify()`
- each message in a separate line
- no headers/footers
- content-type `text/plain`

The new format will be used in NET-273. The format is similar to current `protocol` format, which we could maybe deprecate?