### PR TITLE
Use core-api via NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ EXPOSE 9000
 
 ENV LOG_LEVEL=info
 ENV CONFIG_FILE configs/docker-1.env.json
-ENV STREAMR_URL http://127.0.0.1:8081/streamr-core
+ENV STREAMR_URL http://10.200.10.1
 
 CMD node bin/broker.js ${CONFIG_FILE} --streamrUrl=${STREAMR_URL}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ EXPOSE 9000
 
 ENV LOG_LEVEL=info
 ENV CONFIG_FILE configs/docker-1.env.json
-ENV STREAMR_URL http://10.200.10.1
+ENV STREAMR_URL http://127.0.0.1
 
 CMD node bin/broker.js ${CONFIG_FILE} --streamrUrl=${STREAMR_URL}

--- a/configs/development-1.env.json
+++ b/configs/development-1.env.json
@@ -36,7 +36,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://10.200.10.1",
+  "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/development-1.env.json
+++ b/configs/development-1.env.json
@@ -36,7 +36,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://localhost:8081/streamr-core",
+  "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/development-2.env.json
+++ b/configs/development-2.env.json
@@ -26,7 +26,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://10.200.10.1",
+  "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/development-2.env.json
+++ b/configs/development-2.env.json
@@ -26,7 +26,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://localhost:8081/streamr-core",
+  "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/development-3.env.json
+++ b/configs/development-3.env.json
@@ -26,7 +26,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://10.200.10.1",
+  "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/development-3.env.json
+++ b/configs/development-3.env.json
@@ -26,7 +26,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://localhost:8081/streamr-core",
+  "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/docker-1.env.json
+++ b/configs/docker-1.env.json
@@ -4,11 +4,11 @@
     "name": "docker-1",
     "hostname": "0.0.0.0",
     "port": 30315,
-    "advertisedWsUrl": "ws://127.0.0.1:30315",
+    "advertisedWsUrl": "ws://10.200.10.1:30315",
     "isStorageNode": true,
     "trackers": {
       "registryAddress": "0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF",
-      "jsonRpcProvider": "http://127.0.0.1:8545"
+      "jsonRpcProvider": "http://10.200.10.1:8545"
     },
     "location": {
       "latitude": 60.19,

--- a/configs/docker-1.env.json
+++ b/configs/docker-1.env.json
@@ -35,7 +35,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://localhost:8081/streamr-core",
+  "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/docker-1.env.json
+++ b/configs/docker-1.env.json
@@ -4,11 +4,11 @@
     "name": "docker-1",
     "hostname": "0.0.0.0",
     "port": 30315,
-    "advertisedWsUrl": "ws://10.200.10.1:30315",
+    "advertisedWsUrl": "ws://127.0.0.1:30315",
     "isStorageNode": true,
     "trackers": {
       "registryAddress": "0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF",
-      "jsonRpcProvider": "http://10.200.10.1:8545"
+      "jsonRpcProvider": "http://127.0.0.1:8545"
     },
     "location": {
       "latitude": 60.19,
@@ -35,7 +35,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://10.200.10.1",
+  "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/docker-2.env.json
+++ b/configs/docker-2.env.json
@@ -4,11 +4,11 @@
     "name": "docker-2",
     "hostname": "0.0.0.0",
     "port": 30316,
-    "advertisedWsUrl": "ws://10.200.10.1:30316",
+    "advertisedWsUrl": "ws://127.0.0.1:30316",
     "isStorageNode": false,
     "trackers": {
       "registryAddress": "0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF",
-      "jsonRpcProvider": "http://10.200.10.1:8545"
+      "jsonRpcProvider": "http://127.0.0.1:8545"
     },
     "location": {
       "latitude": 52.52,
@@ -25,7 +25,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://10.200.10.1",
+  "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/docker-2.env.json
+++ b/configs/docker-2.env.json
@@ -25,7 +25,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://localhost:8081/streamr-core",
+  "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/docker-2.env.json
+++ b/configs/docker-2.env.json
@@ -4,11 +4,11 @@
     "name": "docker-2",
     "hostname": "0.0.0.0",
     "port": 30316,
-    "advertisedWsUrl": "ws://127.0.0.1:30316",
+    "advertisedWsUrl": "ws://10.200.10.1:30316",
     "isStorageNode": false,
     "trackers": {
       "registryAddress": "0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF",
-      "jsonRpcProvider": "http://127.0.0.1:8545"
+      "jsonRpcProvider": "http://10.200.10.1:8545"
     },
     "location": {
       "latitude": 52.52,

--- a/configs/docker-3.env.json
+++ b/configs/docker-3.env.json
@@ -4,11 +4,11 @@
     "name": "docker-3",
     "hostname": "0.0.0.0",
     "port": 30317,
-    "advertisedWsUrl": "ws://127.0.0.1:30317",
+    "advertisedWsUrl": "ws://10.200.10.1:30317",
     "isStorageNode": false,
     "trackers": {
       "registryAddress": "0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF",
-      "jsonRpcProvider": "http://127.0.0.1:8545"
+      "jsonRpcProvider": "http://10.200.10.1:8545"
     },
     "location": {
       "latitude": 47.16,

--- a/configs/docker-3.env.json
+++ b/configs/docker-3.env.json
@@ -4,11 +4,11 @@
     "name": "docker-3",
     "hostname": "0.0.0.0",
     "port": 30317,
-    "advertisedWsUrl": "ws://10.200.10.1:30317",
+    "advertisedWsUrl": "ws://127.0.0.1:30317",
     "isStorageNode": false,
     "trackers": {
       "registryAddress": "0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF",
-      "jsonRpcProvider": "http://10.200.10.1:8545"
+      "jsonRpcProvider": "http://127.0.0.1:8545"
     },
     "location": {
       "latitude": 47.16,
@@ -25,7 +25,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://10.200.10.1",
+  "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/configs/docker-3.env.json
+++ b/configs/docker-3.env.json
@@ -25,7 +25,7 @@
     "streamr": null,
     "perNodeMetrics": null
   },
-  "streamrUrl": "http://localhost:8081/streamr-core",
+  "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "adapters": [
     {

--- a/test/integration/ping-pong.test.ts
+++ b/test/integration/ping-pong.test.ts
@@ -43,7 +43,7 @@ describe('ping-pong test between broker and clients', () => {
             uWS.App(),
             wsPort,
             networkNode,
-            new StreamFetcher('http://localhost:8081/streamr-core'),
+            new StreamFetcher('http://10.200.10.1'),
             new Publisher(networkNode, {}, metricsContext),
             metricsContext,
             new SubscriptionManager(networkNode)

--- a/test/integration/ping-pong.test.ts
+++ b/test/integration/ping-pong.test.ts
@@ -43,7 +43,7 @@ describe('ping-pong test between broker and clients', () => {
             uWS.App(),
             wsPort,
             networkNode,
-            new StreamFetcher('http://10.200.10.1'),
+            new StreamFetcher('http://127.0.0.1'),
             new Publisher(networkNode, {}, metricsContext),
             metricsContext,
             new SubscriptionManager(networkNode)

--- a/test/integration/resends-cancelled-on-client-disconnect.test.ts
+++ b/test/integration/resends-cancelled-on-client-disconnect.test.ts
@@ -81,7 +81,7 @@ describe('resend cancellation', () => {
             ws.App(),
             wsPort,
             networkNode,
-            new StreamFetcher(`http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core`),
+            new StreamFetcher(`http://${STREAMR_DOCKER_DEV_HOST}`),
             new Publisher(networkNode, {}, metricsContext),
             metricsContext,
             new SubscriptionManager(networkNode)

--- a/test/sequential/storage/DeleteExpiredCmd.test.ts
+++ b/test/sequential/storage/DeleteExpiredCmd.test.ts
@@ -67,7 +67,7 @@ describe('DeleteExpiredCmd', () => {
             orderMessages: false,
         })
         deleteExpiredCmd = new DeleteExpiredCmd({
-            streamrBaseUrl: `http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core`,
+            streamrBaseUrl: `http://${STREAMR_DOCKER_DEV_HOST}`,
             cassandraUsername: '',
             cassandraPassword: '',
             cassandraHosts: [STREAMR_DOCKER_DEV_HOST],

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,7 +8,7 @@ import { startBroker as createBroker } from '../src/broker'
 import { StorageConfig } from '../src/storage/StorageConfig'
 import { Todo } from './types'
 
-export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '10.200.10.1'
+export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
 const API_URL = `http://${STREAMR_DOCKER_DEV_HOST}/api/v1`
 
 export function formConfig({

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,7 +8,7 @@ import { startBroker as createBroker } from '../src/broker'
 import { StorageConfig } from '../src/storage/StorageConfig'
 import { Todo } from './types'
 
-export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
+export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '10.200.10.1'
 const API_URL = `http://${STREAMR_DOCKER_DEV_HOST}/api/v1`
 
 export function formConfig({
@@ -23,7 +23,7 @@ export function formConfig({
     privateKeyFileName = null,
     certFileName = null,
     streamrAddress = '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
-    streamrUrl = `http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core`,
+    streamrUrl = `http://${STREAMR_DOCKER_DEV_HOST}`,
     reporting = false
 }: Todo) {
     const adapters = []
@@ -123,7 +123,7 @@ export function createClient(wsPort: number, privateKey = fastPrivateKey(), clie
             privateKey
         },
         url: getWsUrl(wsPort),
-        restUrl: `http://${STREAMR_DOCKER_DEV_HOST}:8081/streamr-core/api/v1`,
+        restUrl: `http://${STREAMR_DOCKER_DEV_HOST}/api/v1`,
         ...clientOptions,
     })
 }


### PR DESCRIPTION
Using `http://127.0.0.1` instead of `http://127.0.0.1:8081/streamr-core`

Note that STREAMR_URL is overwritten here: https://github.com/streamr-dev/streamr-docker-dev/blob/master/docker-compose.yml#L98-L121