### PR TITLE
DataQueryEndpoints: msgChainId in range resend 

### DIFF
--- a/src/http/DataQueryEndpoints.ts
+++ b/src/http/DataQueryEndpoints.ts
@@ -194,7 +194,7 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
             })
         } else {
             if ((publisherId && !msgChainId) || (!publisherId && msgChainId)) {
-                res.status(422).send({
+                res.status(400).send({
                     error: 'Invalid combination of "publisherId" and "msgChainId"'
                 })
                 return

--- a/src/http/DataQueryEndpoints.ts
+++ b/src/http/DataQueryEndpoints.ts
@@ -152,7 +152,7 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
         const toTimestamp = parseIntIfExists(req.query.toTimestamp)
         const fromSequenceNumber = parseIntIfExists(req.query.fromSequenceNumber) || MIN_SEQUENCE_NUMBER_VALUE
         const toSequenceNumber = parseIntIfExists(req.query.toSequenceNumber) || MAX_SEQUENCE_NUMBER_VALUE
-        const { publisherId } = req.query
+        const { publisherId, msgChainId } = req.query
         metrics.record('rangeRequests', 1)
 
         if (req.query.fromOffset !== undefined || req.query.toOffset !== undefined) {
@@ -193,6 +193,12 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
                 error: errMsg
             })
         } else {
+            if ((publisherId && !msgChainId) || (!publisherId && msgChainId)) {
+                res.status(422).send({
+                    error: 'Invalid combination of "publisherId" and "msgChainId"'
+                })
+                return
+            }
             const streamingData = storage.requestRange(
                 req.params.id,
                 partition,
@@ -201,7 +207,7 @@ export const router = (storage: Storage, streamFetcher: Todo, metricsContext: Me
                 toTimestamp,
                 toSequenceNumber,
                 (publisherId as string) || null,
-                null,
+                (msgChainId as string) || null
             )
 
             streamData(res, streamingData, (req.query.format as string), version, metrics)

--- a/test/unit/http/DataQueryEndpoints.test.ts
+++ b/test/unit/http/DataQueryEndpoints.test.ts
@@ -97,7 +97,7 @@ describe('DataQueryEndpoints', () => {
             it('responds 422 publisherId+msgChainId combination is invalid in range request', async () => {
                 const base = '/api/v1/streams/streamId/data/partitions/0/range?fromTimestamp=1000&toTimestamp=2000&fromSequenceNumber=1&toSequenceNumber=2'
                 const suffixes = ['publisherId=foo', 'msgChainId=bar']
-                for (let suffix of suffixes) {
+                for (const suffix of suffixes) {
                     await testGetRequest(`${base}&${suffix}`)
                         .expect('Content-Type', /json/)
                         .expect(422, {

--- a/test/unit/http/DataQueryEndpoints.test.ts
+++ b/test/unit/http/DataQueryEndpoints.test.ts
@@ -24,7 +24,7 @@ describe('DataQueryEndpoints', () => {
 
     function createStreamMessage(content: any) {
         return new StreamMessage({
-            messageId: new MessageID('streamId', 0, new Date(2017, 3, 1, 12, 0, 0).getTime(), 0, 'publisherId', '1'),
+            messageId: new MessageID('streamId', 0, new Date(2017, 3, 1, 12, 0, 0).getTime(), 0, 'publisherId', 'msgChainId'),
             content,
         })
     }
@@ -92,6 +92,18 @@ describe('DataQueryEndpoints', () => {
                     .expect(400, {
                         error: 'Query parameter "count" not a number: sixsixsix',
                     }, done)
+            })
+
+            it('responds 422 publisherId+msgChainId combination is invalid in range request', async () => {
+                const base = '/api/v1/streams/streamId/data/partitions/0/range?fromTimestamp=1000&toTimestamp=2000&fromSequenceNumber=1&toSequenceNumber=2'
+                const suffixes = ['publisherId=foo', 'msgChainId=bar']
+                for (let suffix of suffixes) {
+                    await testGetRequest(`${base}&${suffix}`)
+                        .expect('Content-Type', /json/)
+                        .expect(422, {
+                            error: 'Invalid combination of "publisherId" and "msgChainId"',
+                        })
+                }
             })
         })
 
@@ -355,10 +367,32 @@ describe('DataQueryEndpoints', () => {
             })
         })
 
+        describe('?fromTimestamp=1000&toTimestamp=2000&fromSequenceNumber=1&toSequenceNumber=2', () => {
+
+            const query = '?fromTimestamp=1000&toTimestamp=2000&fromSequenceNumber=1&toSequenceNumber=2'
+            it('invokes networkNode#requestResendRange once with correct arguments', async () => {
+                storage.requestRange = jest.fn()
+
+                await testGetRequest(`/api/v1/streams/streamId/data/partitions/0/range${query}`)
+                expect(storage.requestRange).toHaveBeenCalledTimes(1)
+                expect(storage.requestRange).toHaveBeenCalledWith(
+                    'streamId',
+                    0,
+                    1000,
+                    1,
+                    2000,
+                    2,
+                    null,
+                    null,
+                )
+            })
+
+        })
+
         // eslint-disable-next-line max-len
-        describe('?fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=publisherId', () => {
+        describe('?fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=publisherId&msgChainId=msgChainId', () => {
             // eslint-disable-next-line max-len
-            const query = 'fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=publisherId'
+            const query = 'fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=publisherId&msgChainId=msgChainId'
 
             let streamMessages: Todo[]
             beforeEach(() => {
@@ -395,7 +429,7 @@ describe('DataQueryEndpoints', () => {
                     1496415670909,
                     2,
                     'publisherId',
-                    null,
+                    'msgChainId',
                 )
             })
 

--- a/test/unit/http/DataQueryEndpoints.test.ts
+++ b/test/unit/http/DataQueryEndpoints.test.ts
@@ -94,13 +94,13 @@ describe('DataQueryEndpoints', () => {
                     }, done)
             })
 
-            it('responds 422 publisherId+msgChainId combination is invalid in range request', async () => {
+            it('responds 400 and error message if publisherId+msgChainId combination is invalid in range request', async () => {
                 const base = '/api/v1/streams/streamId/data/partitions/0/range?fromTimestamp=1000&toTimestamp=2000&fromSequenceNumber=1&toSequenceNumber=2'
                 const suffixes = ['publisherId=foo', 'msgChainId=bar']
                 for (const suffix of suffixes) {
                     await testGetRequest(`${base}&${suffix}`)
                         .expect('Content-Type', /json/)
-                        .expect(422, {
+                        .expect(400, {
                             error: 'Invalid combination of "publisherId" and "msgChainId"',
                         })
                 }


### PR DESCRIPTION
Add new query parameter for msgChainId for `/streams/:id/data/partitions/:partition/range` endpoint. Validation for correct publisherId+msgChainId combination.