### PR TITLE
Make store() resolve true if actually stored something + improve logging + types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepare": "tsc -p tsconfig-build.json",
     "test": "eslint . && jest test/unit test/integration && npm run test-sequential",
-    "build": "tsc -p tsconfig-build.json --incremental",
+    "build": "tsc -p tsconfig-build.json",
     "test-unit": "jest test/unit",
     "test-sequential": "jest --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
     "test-integration": "jest --forceExit test/integration && npm run test-sequential",

--- a/src/StreamFetcher.ts
+++ b/src/StreamFetcher.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch'
+import fetch, { Headers, Response } from 'node-fetch'
 import memoize from 'memoizee'
 import { getLogger } from './helpers/logger'
 import { HttpError } from './errors/HttpError'
@@ -11,99 +11,112 @@ const logger = getLogger('streamr:StreamFetcher')
 const MAX_AGE = 15 * 60 * 1000 // 15 minutes
 const MAX_AGE_MINUTE = 1000 // 1 minutes
 
-function formHeaders(sessionToken: string|undefined) {
-    const headers: any = {}
+function formHeaders(sessionToken?: string) {
+    const headers: Headers = new Headers()
     if (sessionToken) {
-        headers.Authorization = `Bearer ${sessionToken}`
+        headers.set('Authorization', `Bearer ${sessionToken}`)
     }
     return headers
 }
 
-async function fetchWithErrorLogging(...args: Todo[]) {
+async function fetchWithErrorLogging(...args: Parameters<typeof fetch>) {
     try {
-        // @ts-expect-error
         return await fetch(...args)
-    } catch (e) {
-        logger.error(`failed to communicate with E&E: ${e}`)
-        throw e
+    } catch (err) {
+        logger.error(`failed to communicate with core-api: ${err}`)
+        throw err
     }
 }
 
-async function handleNon2xxResponse(funcName: Todo, response: Todo, streamId: string, sessionToken: string|undefined, method: Todo, url: string) {
-    const errorMsg = await response.text()
+async function handleNon2xxResponse(
+    funcName: string,
+    response: Response,
+    streamId: string,
+    sessionToken: string|undefined|null,
+    method: string,
+    url: string,
+): Promise<HttpError> {
+    const errorMsg = await response.text().catch((err) => {
+        logger.warn('Error reading response text: %s', err)
+        return ''
+    })
     logger.debug(
-        '%s failed with status %d for streamId %s, sessionToken %s : %o',
+        '%s failed with status %d for streamId %s, sessionToken %s: %o',
         funcName, response.status, streamId, sessionToken, errorMsg,
     )
-    throw new HttpError(response.status, method, url)
+    return new HttpError(response.status, method, url)
 }
 
 export class StreamFetcher {
 
     apiUrl: string
-    fetch: Todo
-    checkPermission: Todo
-    authenticate: Todo
+    fetch
+    checkPermission
+    authenticate
 
     constructor(baseUrl: string) {
         this.apiUrl = `${baseUrl}/api/v1`
-        this.fetch = memoize(this._fetch, {
+        this.fetch = memoize<StreamFetcher['_fetch']>(this._fetch, {
             maxAge: MAX_AGE,
             promise: true,
         })
-        this.checkPermission = memoize(this._checkPermission, {
+        this.checkPermission = memoize<StreamFetcher['_checkPermission']>(this._checkPermission, {
             maxAge: MAX_AGE,
             promise: true,
         })
-        this.authenticate = memoize(this._authenticate, {
+        this.authenticate = memoize<StreamFetcher['_authenticate']>(this._authenticate, {
             maxAge: MAX_AGE_MINUTE,
             promise: true,
         })
     }
 
-    async _authenticate(streamId: string, sessionToken: string|undefined, operation = 'stream_subscribe') {
-        await this.checkPermission(streamId, sessionToken, operation)
-        return this.fetch(streamId, sessionToken)
-    }
-
-    async getToken(privateKey: string) {
+    async getToken(privateKey: string): Promise<Todo> {
         const client = new StreamrClient({
             auth: {
-                privateKey
+                privateKey,
             },
             restUrl: this.apiUrl,
             autoConnect: false
         })
-        // @ts-expect-error
-        return await client.session.getSessionToken()
+
+        // @ts-expect-error session is marked internal
+        return client.session.getSessionToken()
+    }
+
+    private async _authenticate(streamId: string, sessionToken: string|undefined, operation = 'stream_subscribe'): Promise<Todo>  {
+        await this.checkPermission(streamId, sessionToken, operation)
+        return this.fetch(streamId, sessionToken)
     }
 
     /**
-     * Returns a Promise that resolves with the stream json. Fails if there is no read permission.
+     * Returns a Promise that resolves with the stream json.
+     * Fails if there is no read permission.
      *
      * @param streamId
      * @param sessionToken
      * @returns {Promise.<TResult>}
      * @private
      */
-    async _fetch(streamId: string, sessionToken: string|undefined) {
+    private async _fetch(streamId: string, sessionToken?: string): Promise<Todo> {
         const url = `${this.apiUrl}/streams/${encodeURIComponent(streamId)}`
         const headers = formHeaders(sessionToken)
 
         const response = await fetchWithErrorLogging(url, {
-            headers
+            headers,
         })
 
         if (response.status !== 200) {
             this.fetch.delete(streamId, sessionToken) // clear cache result
-            return handleNon2xxResponse('_fetch', response, streamId, sessionToken, 'GET', url)
+            throw await handleNon2xxResponse('_fetch', response, streamId, sessionToken, 'GET', url)
         }
+
         return response.json()
     }
 
     /**
-     * Retrieves permissions to a stream, and checks if a permission is granted for the requested operation.
-     * Promise always resolves to true.
+     * Retrieves permissions to a stream, and checks if a permission is granted
+     * for the requested operation.
+     * Promise always resolves to true or throws if permissions are invalid.
      *
      * @param streamId
      * @param sessionToken
@@ -111,10 +124,12 @@ export class StreamFetcher {
      * @returns {Promise}
      * @private
      */
-    async _checkPermission(streamId: string, sessionToken: string|undefined, operation = 'stream_subscribe') {
+    private async _checkPermission(streamId: string, sessionToken: string | undefined | null, operation = 'stream_subscribe'): Promise<true> {
         if (streamId == null) {
-            throw new Error('streamId can not be null!')
+            throw new Error('_checkPermission: streamId can not be null!')
         }
+
+        sessionToken = sessionToken || undefined
 
         const url = `${this.apiUrl}/streams/${encodeURIComponent(streamId)}/permissions/me`
         const headers = formHeaders(sessionToken)
@@ -125,7 +140,7 @@ export class StreamFetcher {
 
         if (response.status !== 200) {
             this.checkPermission.delete(streamId, sessionToken) // clear cache result
-            return handleNon2xxResponse('_checkPermission', response, streamId, sessionToken, 'GET', url)
+            throw await handleNon2xxResponse('_checkPermission', response, streamId, sessionToken, 'GET', url)
         }
 
         const permissions = await response.json()
@@ -137,6 +152,7 @@ export class StreamFetcher {
             'checkPermission failed for streamId %s, sessionToken %s, operation %s. permissions were: %o',
             streamId, sessionToken, operation, permissions,
         )
+
         throw new HttpError(403, 'GET', url)
     }
 }

--- a/src/storage/Batch.ts
+++ b/src/storage/Batch.ts
@@ -125,7 +125,7 @@ export class Batch extends EventEmitter {
 
     push(streamMessage: Protocol.StreamMessage, doneCb?: DoneCallback): void {
         this.streamMessages.push(streamMessage)
-        this.size += Buffer.from(streamMessage.serialize()).length
+        this.size += Buffer.byteLength(streamMessage.serialize())
         if (doneCb) {
             this.doneCbs.push(doneCb)
         }

--- a/src/storage/Batch.ts
+++ b/src/storage/Batch.ts
@@ -20,20 +20,20 @@ export class Batch extends EventEmitter {
         INSERTED: 'inserted'
     })
 
-    _id: BatchId
-    _bucketId: BucketId
+    private _id: BatchId
+    private _bucketId: BucketId
+    logger: Logger
+    private _maxSize: number
+    private _maxRecords: number
+    private _maxRetries : number
+    private _closeTimeout: number
+    private _timeout: NodeJS.Timeout
     createdAt: number
     streamMessages: Protocol.StreamMessage[]
     size: number
     retries: number
     state: State
-    doneCbs: DoneCallback[]
-    logger: Logger
-    _maxSize: number
-    _maxRecords: number
-    _maxRetries : number
-    _closeTimeout: number
-    _timeout: NodeJS.Timeout
+    private doneCbs: DoneCallback[]
 
     constructor(bucketId: BucketId, maxSize: number, maxRecords: number, closeTimeout: number, maxRetries: number) {
         if (!bucketId || !bucketId.length) {
@@ -82,24 +82,24 @@ export class Batch extends EventEmitter {
         this.logger.debug('init new batch')
     }
 
-    reachedMaxRetries() {
+    reachedMaxRetries(): boolean {
         return this.retries === this._maxRetries
     }
 
-    getId() {
+    getId(): string {
         return this._id
     }
 
-    getBucketId() {
+    getBucketId(): string {
         return this._bucketId
     }
 
-    lock() {
+    lock(): void {
         clearTimeout(this._timeout)
         this._setState(Batch.states.LOCKED)
     }
 
-    scheduleInsert() {
+    scheduleInsert(): void {
         clearTimeout(this._timeout)
         this.logger.debug(`scheduleRetry. retries:${this.retries}`)
 
@@ -111,19 +111,19 @@ export class Batch extends EventEmitter {
         }, this._closeTimeout * this.retries)
     }
 
-    done() {
+    done(): void {
         this.doneCbs.forEach((doneCb) => doneCb())
         this.doneCbs = []
     }
 
-    clear() {
+    clear(): void {
         this.logger.debug('cleared')
         clearTimeout(this._timeout)
         this.streamMessages = []
         this._setState(Batch.states.INSERTED)
     }
 
-    push(streamMessage: Protocol.StreamMessage, doneCb?: DoneCallback) {
+    push(streamMessage: Protocol.StreamMessage, doneCb?: DoneCallback): void {
         this.streamMessages.push(streamMessage)
         this.size += Buffer.from(streamMessage.serialize()).length
         if (doneCb) {
@@ -131,18 +131,18 @@ export class Batch extends EventEmitter {
         }
     }
 
-    isFull() {
-        return this.size >= this._maxSize || this._getNumberOrMessages() >= this._maxRecords
+    isFull(): boolean {
+        return this.size >= this._maxSize || this._getNumberOfMessages() >= this._maxRecords
     }
 
-    _getNumberOrMessages() {
+    private _getNumberOfMessages(): number {
         return this.streamMessages.length
     }
 
-    _setState(state: State) {
+    _setState(state: State): void {
         this.state = state
         this.logger.debug(`emit state: ${this.state}`)
-        this.emit(this.state, this.getBucketId(), this.getId(), this.state, this.size, this._getNumberOrMessages())
+        this.emit(this.state, this.getBucketId(), this.getId(), this.state, this.size, this._getNumberOfMessages())
     }
 }
 

--- a/src/storage/Batch.ts
+++ b/src/storage/Batch.ts
@@ -7,7 +7,7 @@ import { BucketId } from './Bucket'
 
 export type BatchId = string
 export type State = string
-export type DoneCallback = () => void
+export type DoneCallback = (err?: Error) => void
 
 export class Batch extends EventEmitter {
 

--- a/src/storage/BatchManager.ts
+++ b/src/storage/BatchManager.ts
@@ -54,9 +54,9 @@ export class BatchManager extends EventEmitter {
         }
 
         // bucketId => batch
-        this.batches = {}
+        this.batches = Object.create(null)
         // batchId => batch
-        this.pendingBatches = {}
+        this.pendingBatches = Object.create(null)
 
         this.cassandraClient = cassandraClient
         this.insertStatement = this.opts.useTtl ? INSERT_STATEMENT_WITH_TTL : INSERT_STATEMENT
@@ -92,8 +92,8 @@ export class BatchManager extends EventEmitter {
 
     stop(): void {
         const { batches, pendingBatches } = this
-        this.batches = {}
-        this.pendingBatches = {}
+        this.batches = Object.create(null)
+        this.pendingBatches = Object.create(null)
         Object.values(batches).forEach((batch) => batch.clear())
         Object.values(pendingBatches).forEach((batch) => batch.clear())
     }

--- a/src/storage/BucketManager.ts
+++ b/src/storage/BucketManager.ts
@@ -57,8 +57,8 @@ export class BucketManager {
             ...opts
         }
 
-        this.streams = {}
-        this.buckets = {}
+        this.streams = Object.create(null)
+        this.buckets = Object.create(null)
 
         this.cassandraClient = cassandraClient
 

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -200,7 +200,7 @@ export class Storage extends EventEmitter {
         if (publisherId != null && msgChainId != null) {
             return this._fetchFromMessageRefForPublisher(streamId, partition, fromTimestamp,
                 fromSequenceNo, publisherId, msgChainId)
-        } 
+        }
         if (publisherId == null && msgChainId == null) { // TODO should add fromSequenceNo to this call (NET-268)
             return this._fetchFromTimestamp(streamId, partition, fromTimestamp)
         }
@@ -216,7 +216,8 @@ export class Storage extends EventEmitter {
             return this._fetchBetweenMessageRefsForPublisher(streamId, partition, fromTimestamp,
                 fromSequenceNo, toTimestamp, toSequenceNo, publisherId, msgChainId)
         }
-        if (publisherId == null && msgChainId == null) {  
+
+        if (publisherId == null && msgChainId == null) {
             return this._fetchBetweenTimestamps(streamId, partition, fromTimestamp, toTimestamp) // TODO should add fromSequenceNo and toSequenceNo to this call (NET-268)
         }
 
@@ -261,7 +262,7 @@ export class Storage extends EventEmitter {
 
         this.bucketManager.getBucketsByTimestamp(streamId, partition, fromTimestamp).then((buckets: Bucket[]) => {
             if (buckets.length === 0) { // TODO not an error as there is no data: do not throw
-                throw new Error('Failed to find buckets')
+                throw new Error(`_fetchFromTimestamp: Failed to find buckets: ${streamId} ${partition}`)
             }
 
             const bucketsForQuery = bucketsToIds(buckets)
@@ -299,7 +300,7 @@ export class Storage extends EventEmitter {
 
         this.bucketManager.getBucketsByTimestamp(streamId, partition, fromTimestamp).then((buckets: Bucket[]) => {
             if (buckets.length === 0) { // TODO not an error as there is no data: do not throw
-                throw new Error('Failed to find buckets')
+                throw new Error(`_fetchFromMessageRefForPublisher: Failed to find buckets: ${streamId} ${partition}`)
             }
 
             const bucketsForQuery = bucketsToIds(buckets)
@@ -337,7 +338,7 @@ export class Storage extends EventEmitter {
 
         this.bucketManager.getBucketsByTimestamp(streamId, partition, fromTimestamp, toTimestamp).then((buckets: Bucket[]) => {
             if (buckets.length === 0) { // TODO not an error as there is no data: do not throw
-                throw new Error('Failed to find buckets')
+                throw new Error(`_fetchBetweenTimestamps: Failed to find buckets: ${streamId} ${partition}`)
             }
 
             const bucketsForQuery = bucketsToIds(buckets)
@@ -377,7 +378,7 @@ export class Storage extends EventEmitter {
 
         this.bucketManager.getBucketsByTimestamp(streamId, partition, fromTimestamp, toTimestamp).then((buckets: Bucket[]) => {
             if (buckets.length === 0) { // TODO not an error as there is no data: do not throw
-                throw new Error('Failed to find buckets')
+                throw new Error(`_fetchBetweenMessageRefsForPublisher: Failed to find buckets: ${streamId} ${partition}`)
             }
 
             const bucketsForQuery = bucketsToIds(buckets)

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -103,7 +103,7 @@ export class Storage extends EventEmitter {
             limit = MAX_RESEND_LAST
         }
 
-        logger.debug(`requestLast, streamId: "${streamId}", partition: "${partition}", limit: "${limit}"`)
+        logger.debug('requestLast %o', { streamId, partition, limit })
 
         const GET_LAST_N_MESSAGES = 'SELECT payload FROM stream_data WHERE '
             + 'stream_id = ? AND partition = ? AND bucket_id IN ? '
@@ -193,10 +193,9 @@ export class Storage extends EventEmitter {
     }
 
     requestFrom(streamId: string, partition: number, fromTimestamp: number, fromSequenceNo: number, publisherId: string|null, msgChainId: string|null): Readable {
-        //TODO: msgChainId is always null, remove on NET-143
-        logger.debug(`requestFrom, streamId: "${streamId}", partition: "${partition}", fromTimestamp: "${fromTimestamp}", fromSequenceNo: `
-            + `"${fromSequenceNo}", publisherId: "${publisherId}", msgChainId: "${msgChainId}"`)
+        logger.debug('requestFrom %o', { streamId, partition, fromTimestamp, fromSequenceNo, publisherId, msgChainId })
 
+        //TODO: msgChainId is always null, remove on NET-143
         if (publisherId != null && msgChainId != null) {
             return this._fetchFromMessageRefForPublisher(streamId, partition, fromTimestamp,
                 fromSequenceNo, publisherId, msgChainId)
@@ -209,8 +208,7 @@ export class Storage extends EventEmitter {
     }
 
     requestRange(streamId: string, partition: number, fromTimestamp: number, fromSequenceNo: number, toTimestamp: number, toSequenceNo: number, publisherId: string|null, msgChainId: string|null): Readable {
-        logger.debug(`requestRange, streamId: "${streamId}", partition: "${partition}", fromTimestamp: "${fromTimestamp}", fromSequenceNo: "${fromSequenceNo}"`
-            + `, toTimestamp: "${toTimestamp}", toSequenceNo: "${toSequenceNo}", publisherId: "${publisherId}", msgChainId: "${msgChainId}"`)
+        logger.debug('requestRange %o', { streamId, partition, fromTimestamp, fromSequenceNo, toTimestamp, toSequenceNo, publisherId, msgChainId })
 
         if (publisherId != null && msgChainId != null) {
             return this._fetchBetweenMessageRefsForPublisher(streamId, partition, fromTimestamp,

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -73,7 +73,7 @@ export class Storage extends EventEmitter {
             if (bucketId) {
                 logger.debug(`found bucketId: ${bucketId}`)
 
-                this.bucketManager.incrementBucket(bucketId, Buffer.from(streamMessage.serialize()).length)
+                this.bucketManager.incrementBucket(bucketId, Buffer.byteLength(streamMessage.serialize()))
                 setImmediate(() => this.batchManager.store(bucketId, streamMessage, (err?: Error) => {
                     if (err) {
                         reject(err)

--- a/src/websocket/RequestHandler.ts
+++ b/src/websocket/RequestHandler.ts
@@ -50,15 +50,15 @@ export class RequestHandler {
 
     handleRequest(connection: Connection, request: Todo): Promise<any> {
         switch (request.type) {
-            case ControlLayer.ControlMessage.TYPES.SubscribeRequest: 
+            case ControlLayer.ControlMessage.TYPES.SubscribeRequest:
                 return this.subscribe(connection, request)
-            case ControlLayer.ControlMessage.TYPES.UnsubscribeRequest: 
+            case ControlLayer.ControlMessage.TYPES.UnsubscribeRequest:
                 return this.unsubscribe(connection, request)
-            case ControlLayer.ControlMessage.TYPES.PublishRequest: 
+            case ControlLayer.ControlMessage.TYPES.PublishRequest:
                 return this.publish(connection, request)
-            case ControlLayer.ControlMessage.TYPES.ResendLastRequest: 
-            case ControlLayer.ControlMessage.TYPES.ResendFromRequest: 
-            case ControlLayer.ControlMessage.TYPES.ResendRangeRequest: 
+            case ControlLayer.ControlMessage.TYPES.ResendLastRequest:
+            case ControlLayer.ControlMessage.TYPES.ResendFromRequest:
+            case ControlLayer.ControlMessage.TYPES.ResendRangeRequest:
                 return this.resend(connection, request)
             default:
                 connection.send(new ControlLayer.ErrorResponse({
@@ -123,7 +123,7 @@ export class RequestHandler {
     private getStreamStorageData(request: ResendFromRequest|ResendLastRequest|ResendRangeRequest) {
         let r
         switch (request.type) {
-            case ControlLayer.ControlMessage.TYPES.ResendLastRequest: 
+            case ControlLayer.ControlMessage.TYPES.ResendLastRequest:
                 r = request as ResendLastRequest
                 return this.networkNode.requestResendLast(
                     r.streamId,
@@ -131,7 +131,7 @@ export class RequestHandler {
                     uuidv4(),
                     r.numberLast,
                 )
-            case ControlLayer.ControlMessage.TYPES.ResendFromRequest: 
+            case ControlLayer.ControlMessage.TYPES.ResendFromRequest:
                 r = request as ResendFromRequest
                 return this.networkNode.requestResendFrom(
                     r.streamId,
@@ -144,7 +144,7 @@ export class RequestHandler {
                     // @ts-expect-error
                     r.msgChainId,
                 )
-            case ControlLayer.ControlMessage.TYPES.ResendRangeRequest: 
+            case ControlLayer.ControlMessage.TYPES.ResendRangeRequest:
                 r = request as ResendRangeRequest
                 return this.networkNode.requestResendRange(
                     r.streamId,
@@ -152,7 +152,7 @@ export class RequestHandler {
                     uuidv4(),
                     r.fromMsgRef.timestamp,
                     // TODO client should provide sequenceNumber, remove MIN_SEQUENCE_NUMBER_VALUE&MAX_SEQUENCE_NUMBER_VALUE defaults when NET-267 have been implemented
-                    r.fromMsgRef.sequenceNumber || MIN_SEQUENCE_NUMBER_VALUE,  
+                    r.fromMsgRef.sequenceNumber || MIN_SEQUENCE_NUMBER_VALUE,
                     r.toMsgRef.timestamp,
                     r.toMsgRef.sequenceNumber || MAX_SEQUENCE_NUMBER_VALUE,
                     r.publisherId,

--- a/test/unit/http/DataQueryEndpoints.test.ts
+++ b/test/unit/http/DataQueryEndpoints.test.ts
@@ -289,10 +289,10 @@ describe('DataQueryEndpoints', () => {
                     }, done)
             })
             it('responds 400 and error message if param "fromTimestamp" not a number', (done) => {
-                testGetRequest('/api/v1/streams/streamId/data/partitions/0/range?fromTimestamp=endOfTime')
+                testGetRequest('/api/v1/streams/streamId/data/partitions/0/range?fromTimestamp=notANumber')
                     .expect('Content-Type', /json/)
                     .expect(400, {
-                        error: 'Query parameter "fromTimestamp" not a number: endOfTime',
+                        error: 'Query parameter "fromTimestamp" not a number: notANumber',
                     }, done)
             })
             it('responds 400 and error message if param "toTimestamp" not given', (done) => {
@@ -305,10 +305,10 @@ describe('DataQueryEndpoints', () => {
                     }, done)
             })
             it('responds 400 and error message if optional param "toTimestamp" not a number', (done) => {
-                testGetRequest('/api/v1/streams/streamId/data/partitions/0/range?fromTimestamp=1&toTimestamp=endOfLife')
+                testGetRequest('/api/v1/streams/streamId/data/partitions/0/range?fromTimestamp=1&toTimestamp=notANumber')
                     .expect('Content-Type', /json/)
                     .expect(400, {
-                        error: 'Query parameter "toTimestamp" not a number: endOfLife',
+                        error: 'Query parameter "toTimestamp" not a number: notANumber',
                     }, done)
             })
         })

--- a/test/unit/storage/StorageConfig.test.ts
+++ b/test/unit/storage/StorageConfig.test.ts
@@ -6,8 +6,8 @@ describe('StorageConfig', () => {
     let listener: StorageConfigListener
 
     beforeEach(() => {
-        // @ts-expect-error
-        config = new StorageConfig()
+        config = new StorageConfig('nodeId', 'http://api-url.com/path')
+        // @ts-expect-error private
         config._setStreams(new Set(['existing1::0', 'existing2::0', 'existing2::1', 'existing3::0']))
         listener = {
             onStreamAdded: jest.fn(),
@@ -17,6 +17,7 @@ describe('StorageConfig', () => {
     })
 
     it('setStreams', () => {
+        // @ts-expect-error private
         config._setStreams(new Set(['existing2::0', 'existing3::0', 'new1::0', 'new2::0']))
         expect(listener.onStreamAdded).toBeCalledTimes(2)
         expect(listener.onStreamAdded).toHaveBeenCalledWith({ id: 'new1', partition: 0 })
@@ -30,6 +31,7 @@ describe('StorageConfig', () => {
     })
 
     it('addStream', () => {
+        // @ts-expect-error private
         config._addStreams(new Set(['loremipsum::0', 'foo::0', 'bar::0']))
         expect(listener.onStreamAdded).toBeCalledTimes(3)
         expect(listener.onStreamAdded).toHaveBeenCalledWith({ id: 'loremipsum', partition: 0 })
@@ -38,6 +40,7 @@ describe('StorageConfig', () => {
     })
 
     it('removeStreams', () => {
+        // @ts-expect-error private
         config._removeStreams(new Set(['existing2::0', 'existing2::1']))
         expect(listener.onStreamRemoved).toBeCalledTimes(2)
         expect(listener.onStreamRemoved).toHaveBeenCalledWith({ id: 'existing2', partition: 0 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,9 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "incremental": true,
+    "sourceMap": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
This is another "miscellaneous" changes PR, but these are all fairly trivial and should be uncontroversial (?).

While I was debugging yesterday I added a bunch of missing types & performed some mild refactoring & logging improvements in the `storage` classes.

Also changed the `store()` signature so it gives a boolean signal as to whether a message was stored or not, based on `messageFilter` result. This could be used in network to decide whether a message was stored or not and respond appropriately.

* Added missing explicit return types as requested by eslint
* Fixed some `Todo` types
* Made many `_methods` `private _methods`
* Swapped some `{}` for `Object.create(null)`
* Swapped `Buffer.from(str).length` with `Buffer.byteLength(str)`
* Enabled incremental tsc builds
* Enabled sourcemaps in tsc builds
